### PR TITLE
- Remove confusing usage of `PaletteModeManager` and `PaletteMode`

### DIFF
--- a/Source/Krypton Docking Examples/Standard Docking/Form1.cs
+++ b/Source/Krypton Docking Examples/Standard Docking/Form1.cs
@@ -234,61 +234,61 @@ namespace StandardDocking
 
         private void button2010Blue_Click(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
             UpdatePaletteButtons();
         }
 
         private void button2010Silver_Click(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
             UpdatePaletteButtons();
         }
 
         private void button2010Black_Click(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
             UpdatePaletteButtons();
         }
 
         private void button2007Blue_Click(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
             UpdatePaletteButtons();
         }
 
         private void button2007Silver_Click(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
             UpdatePaletteButtons();
         }
 
         private void button2007Black_Click(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
             UpdatePaletteButtons();
         }
 
         private void buttonSparkleBlue_Click(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+            kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
             UpdatePaletteButtons();
         }
 
         private void buttonSparkleOrange_Click(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+            kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
             UpdatePaletteButtons();
         }
 
         private void buttonSparklePurple_Click(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.SparklePurple;
+            kryptonManager.GlobalPaletteMode = PaletteMode.SparklePurple;
             UpdatePaletteButtons();
         }
 
         private void buttonSystem_Click(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+            kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
             UpdatePaletteButtons();
         }
 
@@ -301,16 +301,16 @@ namespace StandardDocking
 
         private void UpdatePaletteButtons()
         {
-            button2010Blue.Checked = (kryptonManager.GlobalPaletteMode == PaletteModeManager.Office2010Blue);
-            button2010Silver.Checked = (kryptonManager.GlobalPaletteMode == PaletteModeManager.Office2010Silver);
-            button2010Black.Checked = (kryptonManager.GlobalPaletteMode == PaletteModeManager.Office2010Black);
-            button2007Blue.Checked = (kryptonManager.GlobalPaletteMode == PaletteModeManager.Office2007Blue);
-            button2007Silver.Checked = (kryptonManager.GlobalPaletteMode == PaletteModeManager.Office2007Silver);
-            button2007Black.Checked = (kryptonManager.GlobalPaletteMode == PaletteModeManager.Office2007Black);
-            buttonSparkleBlue.Checked = (kryptonManager.GlobalPaletteMode == PaletteModeManager.SparkleBlue);
-            buttonSparkleOrange.Checked = (kryptonManager.GlobalPaletteMode == PaletteModeManager.SparkleOrange);
-            buttonSparklePurple.Checked = (kryptonManager.GlobalPaletteMode == PaletteModeManager.SparklePurple);
-            buttonSystem.Checked = (kryptonManager.GlobalPaletteMode == PaletteModeManager.ProfessionalSystem);
+            button2010Blue.Checked = (kryptonManager.GlobalPaletteMode == PaletteMode.Office2010Blue);
+            button2010Silver.Checked = (kryptonManager.GlobalPaletteMode == PaletteMode.Office2010Silver);
+            button2010Black.Checked = (kryptonManager.GlobalPaletteMode == PaletteMode.Office2010Black);
+            button2007Blue.Checked = (kryptonManager.GlobalPaletteMode == PaletteMode.Office2007Blue);
+            button2007Silver.Checked = (kryptonManager.GlobalPaletteMode == PaletteMode.Office2007Silver);
+            button2007Black.Checked = (kryptonManager.GlobalPaletteMode == PaletteMode.Office2007Black);
+            buttonSparkleBlue.Checked = (kryptonManager.GlobalPaletteMode == PaletteMode.SparkleBlue);
+            buttonSparkleOrange.Checked = (kryptonManager.GlobalPaletteMode == PaletteMode.SparkleOrange);
+            buttonSparklePurple.Checked = (kryptonManager.GlobalPaletteMode == PaletteMode.SparklePurple);
+            buttonSystem.Checked = (kryptonManager.GlobalPaletteMode == PaletteMode.ProfessionalSystem);
         }
 
         private void ribbonAppButtonExit_Click(object sender, EventArgs e) => Close();

--- a/Source/Krypton Navigator Examples/Basic Events/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Basic Events/Form1.Designer.cs
@@ -264,7 +264,7 @@ namespace BasicEvents
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2010Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Blue;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/Expanding Pages/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Expanding Pages/Form1.Designer.cs
@@ -1198,7 +1198,7 @@ namespace ExpandingPages
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // kryptonPalettes
             // 

--- a/Source/Krypton Navigator Examples/Expanding Pages/Form1.cs
+++ b/Source/Krypton Navigator Examples/Expanding Pages/Form1.cs
@@ -80,31 +80,31 @@ namespace ExpandingPages
             switch (kryptonPalettes.CheckedIndex)
             {
                 case 0:
-                    kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                    kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Blue;
                     break;
                 case 1:
-                    kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                    kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Silver;
                     break;
                 case 2:
-                    kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+                    kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Black;
                     break;
                 case 3:
-                    kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                    kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
                     break;
                 case 4:
-                    kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+                    kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
                     break;
                 case 5:
-                    kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                    kryptonManager1.GlobalPaletteMode = PaletteMode.SparkleBlue;
                     break;
                 case 6:
-                    kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+                    kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Black;
                     break;
                 case 7:
-                    kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+                    kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Silver;
                     break;
                 case 8:
-                    kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                    kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Blue;
                     break;
 
             }

--- a/Source/Krypton Navigator Examples/Navigator Context Menus/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Navigator Context Menus/Form1.Designer.cs
@@ -521,7 +521,7 @@ namespace NavigatorContextMenus
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/Navigator Modes/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Navigator Modes/Form1.Designer.cs
@@ -633,7 +633,7 @@ namespace NavigatorModes
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/Navigator Palettes/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Navigator Palettes/Form1.Designer.cs
@@ -1404,7 +1404,7 @@ namespace NavigatorPalettes
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.SparkleBlue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.SparkleBlue;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/Navigator Playground/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Navigator Playground/Form1.Designer.cs
@@ -236,7 +236,7 @@ namespace NavigatorPlayground
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.SparkleBlue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.SparkleBlue;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/Navigator ToolTips/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Navigator ToolTips/Form1.Designer.cs
@@ -291,7 +291,7 @@ namespace NavigatorToolTips
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/OneNote Tabs/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/OneNote Tabs/Form1.Designer.cs
@@ -139,7 +139,7 @@ namespace OneNoteTabs
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/Orientation + Alignment/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Orientation + Alignment/Form1.Designer.cs
@@ -770,7 +770,7 @@ namespace OrientationPlusAlignment
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/Outlook Mockup/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Outlook Mockup/Form1.Designer.cs
@@ -1267,7 +1267,7 @@ namespace OutlookMockup
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // dataSet
             // 

--- a/Source/Krypton Navigator Examples/Outlook Mockup/Form1.cs
+++ b/Source/Krypton Navigator Examples/Outlook Mockup/Form1.cs
@@ -184,55 +184,55 @@ namespace OutlookMockup
         private void radioOffice2010Blue_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2010Blue.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
         }
 
         private void radioOffice2010Silver_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2010Silver.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
         }
 
         private void radioOffice2010Black_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2010Black.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
         }
 
         private void radioOffice2007Blue_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2007Blue.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
         }
 
         private void radioOffice2007Silver_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2007Silver.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
         }
 
         private void radioOffice2007Black_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2007Black.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
         }
 
         private void radioOffice2003_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2003.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
         }
 
         private void radioSystem_CheckedChanged(object sender, EventArgs e)
         {
             if (radioSystem.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
         }
 
         private void radioSparkle_CheckedChanged(object sender, EventArgs e)
         {
             if (radioSparkle.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
         }
     }
 }

--- a/Source/Krypton Navigator Examples/Per-Tab Buttons/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Per-Tab Buttons/Form1.Designer.cs
@@ -365,7 +365,7 @@
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/Popup Pages/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Popup Pages/Form1.Designer.cs
@@ -525,7 +525,7 @@ namespace PopupPages
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/Singleline + Multiline/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Singleline + Multiline/Form1.Designer.cs
@@ -605,7 +605,7 @@ namespace SinglelinePlusMultiline
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/Tab Border Styles/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Tab Border Styles/Form1.Designer.cs
@@ -570,7 +570,7 @@ namespace TabBorderStyles
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // Form1
             // 

--- a/Source/Krypton Navigator Examples/User Page Creation/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/User Page Creation/Form1.Designer.cs
@@ -137,7 +137,7 @@ namespace UserPageCreation
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.ProfessionalSystem;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.ProfessionalSystem;
             // 
             // Form1
             // 

--- a/Source/Krypton Ribbon Examples/Application Menu/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Application Menu/Form1.Designer.cs
@@ -320,7 +320,7 @@ namespace ApplicationMenu
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Silver;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Silver;
             // 
             // kryptonPanel1
             // 

--- a/Source/Krypton Ribbon Examples/Application Menu/Form1.cs
+++ b/Source/Krypton Ribbon Examples/Application Menu/Form1.cs
@@ -56,7 +56,7 @@ namespace ApplicationMenu
             buttonSparkleOrange.Checked = false;
             buttonSparklePurple.Checked = false;
             buttonSystem.Checked = false;
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Blue;
         }
 
         private void button2010Silver_Click(object sender, EventArgs e)
@@ -72,7 +72,7 @@ namespace ApplicationMenu
             buttonSparkleOrange.Checked = false;
             buttonSparklePurple.Checked = false;
             buttonSystem.Checked = false;
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Silver;
         }
 
         private void button2010Black_Click(object sender, EventArgs e)
@@ -88,7 +88,7 @@ namespace ApplicationMenu
             buttonSparkleOrange.Checked = false;
             buttonSparklePurple.Checked = false;
             buttonSystem.Checked = false;
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Black;
         }
 
 
@@ -105,7 +105,7 @@ namespace ApplicationMenu
             buttonSparkleOrange.Checked = false;
             buttonSparklePurple.Checked = false;
             buttonSystem.Checked = false;
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Blue;
         }
 
         private void buttonSilver_Click(object sender, EventArgs e)
@@ -121,7 +121,7 @@ namespace ApplicationMenu
             buttonSparkleOrange.Checked = false;
             buttonSparklePurple.Checked = false;
             buttonSystem.Checked = false;
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Silver;
         }
 
         private void buttonBlack_Click(object sender, EventArgs e)
@@ -137,7 +137,7 @@ namespace ApplicationMenu
             buttonSparkleOrange.Checked = false;
             buttonSparklePurple.Checked = false;
             buttonSystem.Checked = false;
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Black;
         }
 
         private void button2003_Click(object sender, EventArgs e)
@@ -153,7 +153,7 @@ namespace ApplicationMenu
             buttonSparkleOrange.Checked = false;
             buttonSparklePurple.Checked = false;
             buttonSystem.Checked = false;
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
         }
 
         private void buttonSparkleBlue_Click(object sender, EventArgs e)
@@ -169,7 +169,7 @@ namespace ApplicationMenu
             buttonSparkleOrange.Checked = false;
             buttonSparklePurple.Checked = false;
             buttonSystem.Checked = false;
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.SparkleBlue;
         }
 
         private void buttonSparkleOrange_Click(object sender, EventArgs e)
@@ -185,7 +185,7 @@ namespace ApplicationMenu
             buttonSparkleOrange.Checked = true;
             buttonSparklePurple.Checked = false;
             buttonSystem.Checked = false;
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.SparkleOrange;
         }
 
         private void buttonSparklePurple_Click(object sender, EventArgs e)
@@ -201,7 +201,7 @@ namespace ApplicationMenu
             buttonSparkleOrange.Checked = false;
             buttonSparklePurple.Checked = true;
             buttonSystem.Checked = false;
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparklePurple;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.SparklePurple;
         }
 
         private void buttonSystem_Click(object sender, EventArgs e)
@@ -214,7 +214,7 @@ namespace ApplicationMenu
             buttonSparkleOrange.Checked = false;
             buttonSparklePurple.Checked = false;
             buttonSystem.Checked = true;
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
         }
     }
 }

--- a/Source/Krypton Ribbon Examples/Auto Shrinking Groups/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Auto Shrinking Groups/Form1.Designer.cs
@@ -815,7 +815,7 @@ namespace AutoShrinkingGroups
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Black;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Black;
             // 
             // Form1
             // 

--- a/Source/Krypton Ribbon Examples/Contextual Tabs/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Contextual Tabs/Form1.Designer.cs
@@ -453,7 +453,7 @@ namespace ContextualTabs
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2010Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Blue;
             // 
             // Form1
             // 

--- a/Source/Krypton Ribbon Examples/Contextual Tabs/Form1.cs
+++ b/Source/Krypton Ribbon Examples/Contextual Tabs/Form1.cs
@@ -81,67 +81,67 @@ namespace ContextualTabs
         private void radioOffice2010Blue_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2010Blue.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
         }
 
         private void radioOffice2010Silver_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2010Silver.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
         }
 
         private void radioOffice2010Black_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2010Black.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
         }
 
         private void radioOffice2007Blue_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2007Blue.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
         }
 
         private void radioOffice2007Silver_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2007Silver.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
         }
 
         private void radioOffice2007Black_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2007Black.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
         }
 
         private void radioOffice2003_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2003.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
         }
 
         private void radioSparkleBlue_CheckedChanged(object sender, EventArgs e)
         {
             if (radioSparkleBlue.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
         }
 
         private void radioSparkleOrange_CheckedChanged(object sender, EventArgs e)
         {
             if (radioSparkleOrange.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
         }
 
         private void radioSparklePurple_CheckedChanged(object sender, EventArgs e)
         {
             if (radioSparklePurple.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparklePurple;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparklePurple;
         }
 
         private void radioSystem_CheckedChanged(object sender, EventArgs e)
         {
             if (radioSystem.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
         }
 
         private void appMenu_Click(object sender, EventArgs e)

--- a/Source/Krypton Ribbon Examples/KeyTips + Keyboard Access/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/KeyTips + Keyboard Access/Form1.Designer.cs
@@ -885,7 +885,7 @@ namespace KeyTipsAndKeyboardAccess
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2010Black;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Black;
             // 
             // Form1
             // 

--- a/Source/Krypton Ribbon Examples/KeyTips + Keyboard Access/Form1.cs
+++ b/Source/Krypton Ribbon Examples/KeyTips + Keyboard Access/Form1.cs
@@ -33,29 +33,29 @@ namespace KeyTipsAndKeyboardAccess
         private void checkSetPalette_CheckedButtonChanged(object sender, EventArgs e)
         {
             if (checkSetPalette.CheckedButton == buttonOffice2007Blue)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
             else if (checkSetPalette.CheckedButton == buttonOffice2007Silver)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
             else if (checkSetPalette.CheckedButton == buttonOffice2007Black)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
             else if (checkSetPalette.CheckedButton == buttonProfessional2003)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
             else if (checkSetPalette.CheckedButton == buttonProfessionalSystem)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
             else if (checkSetPalette.CheckedButton == buttonSparkleBlue)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
             else if (checkSetPalette.CheckedButton == buttonSparkleOrange)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
             else if (checkSetPalette.CheckedButton == buttonSparklePurple)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparklePurple;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparklePurple;
             else if (checkSetPalette.CheckedButton == buttonOffice2010Blue)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
             else if (checkSetPalette.CheckedButton == buttonOffice2010Silver)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
             else if (checkSetPalette.CheckedButton == buttonOffice2010Black)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
             else if (checkSetPalette.CheckedButton == buttonOffice365Black)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Microsoft365Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Microsoft365Black;
         }
 
         private void OnDialogBoxLauncherClick(object sender, EventArgs e)

--- a/Source/Krypton Ribbon Examples/KryptonGallery Examples/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/KryptonGallery Examples/Form1.Designer.cs
@@ -327,7 +327,7 @@ namespace KryptonGalleryExamples
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Black;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Black;
             // 
             // Form1
             // 

--- a/Source/Krypton Ribbon Examples/MDI Ribbon/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/MDI Ribbon/Form1.Designer.cs
@@ -202,7 +202,7 @@ namespace MDIRibbon
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Black;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Black;
             // 
             // Form1
             // 

--- a/Source/Krypton Ribbon Examples/MDI Ribbon/Form2.Designer.cs
+++ b/Source/Krypton Ribbon Examples/MDI Ribbon/Form2.Designer.cs
@@ -188,7 +188,7 @@ namespace MDIRibbon
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Black;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Black;
             // 
             // Form2
             // 

--- a/Source/Krypton Ribbon Examples/MDI Ribbon/Form2.cs
+++ b/Source/Krypton Ribbon Examples/MDI Ribbon/Form2.cs
@@ -48,67 +48,67 @@ namespace MDIRibbon
         private void radioSystem_CheckedChanged(object sender, EventArgs e)
         {
             if (radioSystem.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
         }
 
         private void radioOffice2003_CheckedChanged(object sender, EventArgs e)
         {
             if (radioOffice2003.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
         }
 
         private void radio2010Blue_CheckedChanged(object sender, EventArgs e)
         {
             if (radio2010Blue.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
         }
 
         private void radio2010Silver_CheckedChanged(object sender, EventArgs e)
         {
             if (radio2010Silver.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
         }
 
         private void radio2010Black_CheckedChanged(object sender, EventArgs e)
         {
             if (radio2010Black.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
         }
 
         private void radioBlue_CheckedChanged(object sender, EventArgs e)
         {
             if (radioBlue.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
         }
 
         private void radioSilver_CheckedChanged(object sender, EventArgs e)
         {
             if (radioSilver.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
         }
 
         private void radioBlack_CheckedChanged(object sender, EventArgs e)
         {
             if (radioBlack.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
         }
 
         private void radioSparkleBlue_CheckedChanged(object sender, EventArgs e)
         {
             if (radioSparkleBlue.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
         }
 
         private void radioSparkleOrange_CheckedChanged(object sender, EventArgs e)
         {
             if (radioSparkleOrange.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
         }
 
         private void radioSparklePurple_CheckedChanged(object sender, EventArgs e)
         {
             if (radioSparklePurple.Checked)
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparklePurple;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparklePurple;
         }
 
         private void OnPaletteChanged(object sender, EventArgs e)
@@ -121,37 +121,37 @@ namespace MDIRibbon
         {
             switch(kryptonManager.GlobalPaletteMode)
             {
-                case PaletteModeManager.ProfessionalSystem:
+                case PaletteMode.ProfessionalSystem:
                     radioSystem.Checked = true;
                     break;
-                case PaletteModeManager.ProfessionalOffice2003:
+                case PaletteMode.ProfessionalOffice2003:
                     radioOffice2003.Checked = true;
                     break;
-                case PaletteModeManager.Office2007Blue:
+                case PaletteMode.Office2007Blue:
                     radioBlue.Checked = true;
                     break;
-                case PaletteModeManager.Office2007Silver:
+                case PaletteMode.Office2007Silver:
                     radioSilver.Checked = true;
                     break;
-                case PaletteModeManager.Office2007Black:
+                case PaletteMode.Office2007Black:
                     radioBlack.Checked = true;
                     break;
-                case PaletteModeManager.SparkleBlue:
+                case PaletteMode.SparkleBlue:
                     radioSparkleBlue.Checked = true;
                     break;
-                case PaletteModeManager.SparkleOrange:
+                case PaletteMode.SparkleOrange:
                     radioSparkleOrange.Checked = true;
                     break;
-                case PaletteModeManager.SparklePurple:
+                case PaletteMode.SparklePurple:
                     radioSparklePurple.Checked = true;
                     break;
-                case PaletteModeManager.Office2010Blue:
+                case PaletteMode.Office2010Blue:
                     radio2010Blue.Checked = true;
                     break;
-                case PaletteModeManager.Office2010Silver:
+                case PaletteMode.Office2010Silver:
                     radio2010Silver.Checked = true;
                     break;
-                case PaletteModeManager.Office2010Black:
+                case PaletteMode.Office2010Black:
                     radio2010Black.Checked = true;
                     break;
             }

--- a/Source/Krypton Ribbon Examples/Outlook Mail Clone/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Outlook Mail Clone/Form1.Designer.cs
@@ -2995,7 +2995,7 @@ namespace OutlookMailClone
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007BlackDarkMode;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007BlackDarkMode;
             // 
             // Form1
             // 

--- a/Source/Krypton Ribbon Examples/Quick Access Toolbar/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Quick Access Toolbar/Form1.Designer.cs
@@ -108,7 +108,7 @@ namespace QuickAccessToolbar
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // panelFill
             // 

--- a/Source/Krypton Ribbon Examples/Ribbon + Navigator + Workspace/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Ribbon + Navigator + Workspace/Form1.Designer.cs
@@ -180,7 +180,7 @@ namespace RibbonAndNavigatorAndWorkspace
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // panelFill
             // 
@@ -819,7 +819,6 @@ namespace RibbonAndNavigatorAndWorkspace
             this.kryptonRibbon.RibbonTabs.AddRange(new Krypton.Ribbon.KryptonRibbonTab[] {
             this.kryptonRibbonTab1,
             this.kryptonRibbonTab2});
-            this.kryptonRibbon.SelectedContext = null;
             this.kryptonRibbon.SelectedTab = this.kryptonRibbonTab1;
             this.kryptonRibbon.Size = new System.Drawing.Size(851, 169);
             this.kryptonRibbon.TabIndex = 0;
@@ -1278,7 +1277,7 @@ namespace RibbonAndNavigatorAndWorkspace
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(851, 732);
-            //this.CloseBox = false;
+            this.CloseBox = false;
             this.Controls.Add(this.panelFill);
             this.Controls.Add(this.kryptonRibbon);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));

--- a/Source/Krypton Ribbon Examples/Ribbon + Navigator + Workspace/Form1.cs
+++ b/Source/Krypton Ribbon Examples/Ribbon + Navigator + Workspace/Form1.cs
@@ -49,7 +49,7 @@ namespace RibbonAndNavigatorAndWorkspace
             if (radioOffice2010Blue.Checked)
             {
                 navigatorOutlook.DismissPopups();
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
             }
         }
 
@@ -58,7 +58,7 @@ namespace RibbonAndNavigatorAndWorkspace
             if (radioOffice2010Silver.Checked)
             {
                 navigatorOutlook.DismissPopups();
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
             }
         }
 
@@ -67,7 +67,7 @@ namespace RibbonAndNavigatorAndWorkspace
             if (radioOffice2010Black.Checked)
             {
                 navigatorOutlook.DismissPopups();
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
             }
         }
 
@@ -76,7 +76,7 @@ namespace RibbonAndNavigatorAndWorkspace
             if (radioOffice2007Blue.Checked)
             {
                 navigatorOutlook.DismissPopups();
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
             }
         }
 
@@ -85,7 +85,7 @@ namespace RibbonAndNavigatorAndWorkspace
             if (radioOffice2007Silver.Checked)
             {
                 navigatorOutlook.DismissPopups();
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
             }
         }
 
@@ -94,7 +94,7 @@ namespace RibbonAndNavigatorAndWorkspace
             if (radioOffice2007Black.Checked)
             {
                 navigatorOutlook.DismissPopups();
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
             }
         }
 
@@ -103,7 +103,7 @@ namespace RibbonAndNavigatorAndWorkspace
             if (radioOffice2003.Checked)
             {
                 navigatorOutlook.DismissPopups();
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
             }
         }
 
@@ -112,7 +112,7 @@ namespace RibbonAndNavigatorAndWorkspace
             if (radioSparkleBlue.Checked)
             {
                 navigatorOutlook.DismissPopups();
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
             }
         }
 
@@ -121,7 +121,7 @@ namespace RibbonAndNavigatorAndWorkspace
             if (radioSparkleOrange.Checked)
             {
                 navigatorOutlook.DismissPopups();
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
             }
         }
 
@@ -130,7 +130,7 @@ namespace RibbonAndNavigatorAndWorkspace
             if (radioSparklePurple.Checked)
             {
                 navigatorOutlook.DismissPopups();
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparklePurple;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparklePurple;
             }
         }
 
@@ -139,7 +139,7 @@ namespace RibbonAndNavigatorAndWorkspace
             if (radioSystem.Checked)
             {
                 navigatorOutlook.DismissPopups();
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
             }
         }
 

--- a/Source/Krypton Ribbon Examples/Ribbon Controls/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Ribbon Controls/Form1.Designer.cs
@@ -664,7 +664,7 @@ namespace RibbonControls
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // kryptonRibbonGroupColorButton1
             // 

--- a/Source/Krypton Ribbon Examples/Ribbon Controls/Form1.cs
+++ b/Source/Krypton Ribbon Examples/Ribbon Controls/Form1.cs
@@ -30,7 +30,7 @@ namespace RibbonControls
                 miscCmbTheme.ComboBox.StateCommon.ComboBox.Content.Font;
             // Hook into changes in the global palette
             ThemeManager.PropagateThemeSelector(miscCmbTheme.ComboBox);
-            miscCmbTheme.Text = ThemeManager.ReturnPaletteModeManagerAsString(kryptonManager.GlobalPaletteMode);
+            miscCmbTheme.Text = ThemeManager.ReturnPaletteModeAsString(kryptonManager.GlobalPaletteMode);
         }
 
         private LinkLabel CreateLinkLabel(string text)
@@ -110,47 +110,47 @@ namespace RibbonControls
 
         private void rbOffice2010Blue_CheckedChanged(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
         }
 
         private void rbOffice2010Silver_CheckedChanged(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
         }
 
         private void rbOffice2010Black_CheckedChanged(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
         }
 
         private void rbOffice2007Blue_CheckedChanged(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
         }
 
         private void rbOffice2007Silver_CheckedChanged(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
         }
 
         private void rbOffice2007Black_CheckedChanged(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+            kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
         }
 
         private void rbOffice2003_CheckedChanged(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+            kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
         }
 
         private void rbSystem_CheckedChanged(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+            kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
         }
 
         private void rbSparkle_CheckedChanged(object sender, EventArgs e)
         {
-            kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+            kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
         }
 
         private void appMenu_Click(object sender, EventArgs e)

--- a/Source/Krypton Ribbon Examples/Ribbon Gallery/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Ribbon Gallery/Form1.Designer.cs
@@ -281,7 +281,7 @@ namespace RibbonGallery
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // Form1
             // 

--- a/Source/Krypton Ribbon Examples/Ribbon Gallery/Form1.cs
+++ b/Source/Krypton Ribbon Examples/Ribbon Gallery/Form1.cs
@@ -69,7 +69,7 @@ namespace RibbonGallery
         {
             if (kryptonRibbonGroupButton1.Checked)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Blue;
                 kryptonRibbonGroupButton2.Checked = false;
                 kryptonRibbonGroupButton3.Checked = false;
             }
@@ -79,7 +79,7 @@ namespace RibbonGallery
         {
             if (kryptonRibbonGroupButton2.Checked)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Silver;
                 kryptonRibbonGroupButton1.Checked = false;
                 kryptonRibbonGroupButton3.Checked = false;
             }
@@ -89,7 +89,7 @@ namespace RibbonGallery
         {
             if (kryptonRibbonGroupButton3.Checked)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.SparkleOrange;
                 kryptonRibbonGroupButton1.Checked = false;
                 kryptonRibbonGroupButton2.Checked = false;
             }

--- a/Source/Krypton Ribbon Examples/Ribbon ToolTips/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Ribbon ToolTips/Form1.Designer.cs
@@ -383,7 +383,7 @@ namespace RibbonToolTips
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // Form1
             // 

--- a/Source/Krypton Toolkit Examples/ButtonSpec Playground/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/ButtonSpec Playground/Form1.Designer.cs
@@ -111,7 +111,7 @@ namespace ButtonSpecPlayground
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // kryptonButtonAdd
             // 

--- a/Source/Krypton Toolkit Examples/Child Control Stack/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Child Control Stack/Form1.Designer.cs
@@ -538,7 +538,7 @@ namespace ChildControlStack
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // Form1
             // 

--- a/Source/Krypton Toolkit Examples/Child Control Stack/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Child Control Stack/Form1.cs
@@ -35,7 +35,7 @@ namespace ChildControlStack
         {
             if (!toolOffice2010.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
                 toolOffice2010.Checked = menuOffice2010.Checked = true;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSystem.Checked = menuSystem.Checked = false;
@@ -47,7 +47,7 @@ namespace ChildControlStack
         {
             if (!toolOffice2007.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = true;
                 toolSystem.Checked = menuSystem.Checked = false;
@@ -59,7 +59,7 @@ namespace ChildControlStack
         {
             if (!toolSystem.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSystem.Checked = menuSystem.Checked = true;
@@ -71,7 +71,7 @@ namespace ChildControlStack
         {
            if (!toolSparkle.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSystem.Checked = menuSystem.Checked = false;

--- a/Source/Krypton Toolkit Examples/Custom Control using Palettes/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Custom Control using Palettes/Form1.Designer.cs
@@ -53,7 +53,7 @@ namespace CustomControlUsingPalettes
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // buttonSparkle
             // 

--- a/Source/Krypton Toolkit Examples/Custom Control using Palettes/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Custom Control using Palettes/Form1.cs
@@ -27,19 +27,19 @@ namespace CustomControlUsingPalettes
             switch (kryptonCheckSet.CheckedIndex)
             {
                 case 0:
-                    kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                    kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
                     break;
                 case 1:
-                    kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                    kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
                     break;
                 case 2:
                     kryptonManager.GlobalPalette = kryptonPaletteCustom;
                     break;
                 case 3:
-                    kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                    kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
                     break;
                 case 4:
-                    kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                    kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
                     break;
             }
         }

--- a/Source/Krypton Toolkit Examples/Custom Control using Renderers/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Custom Control using Renderers/Form1.Designer.cs
@@ -260,7 +260,7 @@ namespace CustomControlUsingRenderers
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // kryptonCheckSet
             // 

--- a/Source/Krypton Toolkit Examples/Custom Control using Renderers/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Custom Control using Renderers/Form1.cs
@@ -27,19 +27,19 @@ namespace CustomControlUsingRenderers
             switch (kryptonCheckSet.CheckedIndex)
             {
                 case 0:
-                    kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                    kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
                     break;
                 case 1:
-                    kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                    kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
                     break;
                 case 2:
                     kryptonManager.GlobalPalette = kryptonPaletteCustom;
                     break;
                 case 3:
-                    kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                    kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
                     break;
                 case 4:
-                    kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                    kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
                     break;
             }
         }

--- a/Source/Krypton Toolkit Examples/Expanding HeaderGroups (DockStyle)/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Expanding HeaderGroups (DockStyle)/Form1.Designer.cs
@@ -492,7 +492,7 @@ namespace ExpandingHeaderGroupsDockStyle
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // statusStrip1
             // 

--- a/Source/Krypton Toolkit Examples/Expanding HeaderGroups (DockStyle)/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Expanding HeaderGroups (DockStyle)/Form1.cs
@@ -24,7 +24,7 @@ namespace ExpandingHeaderGroupsDockStyle
         {
             if (!toolOffice2010.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
                 toolOffice2010.Checked = menuOffice2010.Checked = true;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSparkle.Checked = menuSparkle.Checked = false;
@@ -36,7 +36,7 @@ namespace ExpandingHeaderGroupsDockStyle
         {
             if (!toolOffice2007.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = true;
                 toolSparkle.Checked = menuSparkle.Checked = false;
@@ -48,7 +48,7 @@ namespace ExpandingHeaderGroupsDockStyle
         {
             if (!toolSparkle.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSparkle.Checked = menuSparkle.Checked = true;
@@ -60,7 +60,7 @@ namespace ExpandingHeaderGroupsDockStyle
         {
             if (!toolSystem.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSparkle.Checked = menuSparkle.Checked = false;

--- a/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Splitters)/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Splitters)/Form1.Designer.cs
@@ -438,7 +438,7 @@ namespace ExpandingHeaderGroupsSplitters
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // statusStrip1
             // 

--- a/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Splitters)/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Splitters)/Form1.cs
@@ -157,7 +157,7 @@ namespace ExpandingHeaderGroupsSplitters
         {
             if (!toolOffice2010.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
                 toolOffice2010.Checked = menuOffice2010.Checked = true;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSystem.Checked = menuSystem.Checked = false;
@@ -170,7 +170,7 @@ namespace ExpandingHeaderGroupsSplitters
         {
             if (!toolOffice2007.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = true;
                 toolSystem.Checked = menuSystem.Checked = false;
@@ -183,7 +183,7 @@ namespace ExpandingHeaderGroupsSplitters
         {
             if (!toolSystem.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSystem.Checked = menuSystem.Checked = true;
@@ -196,7 +196,7 @@ namespace ExpandingHeaderGroupsSplitters
         {
             if (!toolSparkle.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSystem.Checked = menuSystem.Checked = false;

--- a/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Stack)/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Stack)/Form1.Designer.cs
@@ -535,7 +535,7 @@ namespace ExpandingHeaderGroupsStack
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // statusStrip1
             // 

--- a/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Stack)/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Stack)/Form1.cs
@@ -27,7 +27,7 @@ namespace ExpandingHeaderGroupsStack
         {
             if (!toolOffice2010.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
                 toolOffice2010.Checked = menuOffice2010.Checked = true;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSparkle.Checked = menuSparkle.Checked = false;
@@ -39,7 +39,7 @@ namespace ExpandingHeaderGroupsStack
         {
             if (!toolOffice2007.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = true;
                 toolSparkle.Checked = menuSparkle.Checked = false;
@@ -51,7 +51,7 @@ namespace ExpandingHeaderGroupsStack
         {
             if (!toolSparkle.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSparkle.Checked = menuSparkle.Checked = true;
@@ -63,7 +63,7 @@ namespace ExpandingHeaderGroupsStack
         {
             if (!toolSystem.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
                 toolOffice2010.Checked = menuOffice2010.Checked = false;
                 toolOffice2007.Checked = menuOffice2007.Checked = false;
                 toolSparkle.Checked = menuSparkle.Checked = false;

--- a/Source/Krypton Toolkit Examples/Input Form/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Input Form/Form1.Designer.cs
@@ -658,7 +658,7 @@ namespace InputForm
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // Form1
             // 

--- a/Source/Krypton Toolkit Examples/Input Form/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Input Form/Form1.cs
@@ -21,7 +21,7 @@ namespace InputForm
 
         private void office2010_Click(object sender, EventArgs e)
         {
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Blue;
             toolStripOffice2010.Checked = true;
             toolStripOffice2007.Checked = false;
             toolStripSystem.Checked = false;
@@ -34,7 +34,7 @@ namespace InputForm
 
         private void office2007_Click(object sender, EventArgs e)
         {
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Blue;
             toolStripOffice2010.Checked = false;
             toolStripOffice2007.Checked = true;
             toolStripSystem.Checked = false;
@@ -47,7 +47,7 @@ namespace InputForm
 
         private void sparkle_Click(object sender, EventArgs e)
         {
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.SparkleBlue;
             toolStripOffice2010.Checked = false;
             toolStripOffice2007.Checked = false;
             toolStripSystem.Checked = false;
@@ -60,7 +60,7 @@ namespace InputForm
 
         private void system_Click(object sender, EventArgs e)
         {
-            kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+            kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
             toolStripOffice2010.Checked = false;
             toolStripOffice2007.Checked = false;
             toolStripSystem.Checked = true;

--- a/Source/Krypton Toolkit Examples/KryptonBorderEdge Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonBorderEdge Examples/Form1.Designer.cs
@@ -787,7 +787,7 @@ namespace KryptonBorderEdgeExamples
             // 
             this.kryptonPaletteOffice2007Blue.BaseRenderMode = Krypton.Toolkit.RendererMode.Inherit;
             this.kryptonManager.GlobalPalette = this.kryptonPaletteOffice2007Blue;
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Custom;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Custom;
             // 
             // kryptonPaletteOffice2010Blue
             // 

--- a/Source/Krypton Toolkit Examples/KryptonBreadCrumb Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonBreadCrumb Examples/Form1.Designer.cs
@@ -1250,7 +1250,7 @@
             // kryptonManager1
             // 
             this.kryptonManager1.GlobalPalette = this.kryptonPaletteOffice2007Blue;
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Custom;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Custom;
             // 
             // kryptonPaletteOffice2007Blue
             // 

--- a/Source/Krypton Toolkit Examples/KryptonCheckedListBox Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonCheckedListBox Examples/Form1.Designer.cs
@@ -251,7 +251,7 @@ namespace KryptonCheckedListBoxExamples
             // 
             this.kryptonPaletteOffice2007Blue.BaseRenderMode = Krypton.Toolkit.RendererMode.Inherit;
             this.kryptonManager1.GlobalPalette = this.kryptonPaletteOffice2007Blue;
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Custom;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Custom;
             // 
             // Form1
             // 

--- a/Source/Krypton Toolkit Examples/KryptonCheckedListBox Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonCheckedListBox Examples/Form1.cs
@@ -102,19 +102,19 @@ namespace KryptonCheckedListBoxExamples
         {
             if (kryptonCheckSet.CheckedButton == check2007Blue)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Blue;
             }
             else if (kryptonCheckSet.CheckedButton == check2010Blue)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Blue;
             }
             else if (kryptonCheckSet.CheckedButton == checkSparkle)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.SparkleBlue;
             }
             else if (kryptonCheckSet.CheckedButton == checkSystem)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
             }
         }
 

--- a/Source/Krypton Toolkit Examples/KryptonColorDialog Example/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonColorDialog Example/Form1.cs
@@ -16,17 +16,17 @@ namespace KryptonFontDialog_Example_2019
 
         }
 
-        private void Palette2010Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+        private void Palette2010Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
 
-        private void Palette2010Silver_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+        private void Palette2010Silver_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
 
-        private void Palette2010Black_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+        private void Palette2010Black_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
 
-        private void Palette2007Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+        private void Palette2007Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
 
-        private void PaletteSparkleOrange_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+        private void PaletteSparkleOrange_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
 
-        private void PaletteProfessional_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+        private void PaletteProfessional_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
 
         private int[] customColors;
         private void ButtonShowFontDialog_Click(object sender, EventArgs e)

--- a/Source/Krypton Toolkit Examples/KryptonDataGridView Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonDataGridView Examples/Form1.Designer.cs
@@ -555,7 +555,7 @@ namespace KryptonDataGridViewExamples
             // kryptonManager
             // 
             this.kryptonManager.GlobalPalette = this.kryptonPalette;
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Custom;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Custom;
             // 
             // colDateTime
             // 

--- a/Source/Krypton Toolkit Examples/KryptonDomainUpDown Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonDomainUpDown Examples/Form1.Designer.cs
@@ -803,7 +803,7 @@
             this.kryptonPalette.GridStyles.GridCustom1.StateTracking.HeaderRow.Content.MultiLineH = Krypton.Toolkit.PaletteRelativeAlign.Inherit;
             this.kryptonPalette.GridStyles.GridCustom1.StateTracking.HeaderRow.Content.Trim = Krypton.Toolkit.PaletteTextTrim.Inherit;
             this.kryptonManager1.GlobalPalette = this.kryptonPalette;
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Custom;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Custom;
             // 
             // Form1
             // 

--- a/Source/Krypton Toolkit Examples/KryptonDomainUpDown Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonDomainUpDown Examples/Form1.cs
@@ -30,13 +30,13 @@ namespace KryptonDomainUpDownExamples
             // Setup the property grid to edit this domain upo-down control
             propertyGrid.SelectedObject = new KryptonDomainUpDownProxy(sender as KryptonDomainUpDown);
 
-        private void buttonOffice2010Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+        private void buttonOffice2010Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Blue;
 
-        private void buttonOffice2007Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+        private void buttonOffice2007Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Blue;
 
-        private void buttonSystem_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+        private void buttonSystem_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
 
-        private void buttonSparkleBlue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+        private void buttonSparkleBlue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.SparkleBlue;
 
         private void buttonSpecAny1_Click(object sender, EventArgs e) => dud5.Text = string.Empty;
 

--- a/Source/Krypton Toolkit Examples/KryptonFontDialog Example/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonFontDialog Example/Form1.cs
@@ -14,17 +14,17 @@ namespace KryptonFontDialog_Example_2019
             fontLast = Font;
         }
 
-        private void Palette2010Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+        private void Palette2010Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
 
-        private void Palette2010Silver_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+        private void Palette2010Silver_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
 
-        private void Palette2010Black_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+        private void Palette2010Black_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
 
-        private void Palette2007Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+        private void Palette2007Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
 
-        private void PaletteSparkleOrange_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+        private void PaletteSparkleOrange_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
 
-        private void PaletteProfessional_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+        private void PaletteProfessional_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
 
         private void FolderBrowserDialog1_HelpRequest(object sender, EventArgs e)
         {

--- a/Source/Krypton Toolkit Examples/KryptonForm Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonForm Examples/Form1.cs
@@ -33,17 +33,17 @@ namespace KryptonFormExamples
             RecalcNonClient();
 
             kryptonManager.GlobalPaletteMode = kryptonCheckSetPalettes.CheckedIndex switch {
-                0 => PaletteModeManager.Microsoft365Blue,
-                1 => PaletteModeManager.ProfessionalSystem,
-                2 => PaletteModeManager.Office2007Black,
-                3 => PaletteModeManager.Office2007Silver,
-                4 => PaletteModeManager.Office2007Blue,
-                5 => PaletteModeManager.ProfessionalOffice2003,
-                6 => PaletteModeManager.SparkleBlue,
-                7 => PaletteModeManager.SparkleOrange,
-                8 => PaletteModeManager.Office2010Black,
-                9 => PaletteModeManager.Office2010Silver,
-                10 => PaletteModeManager.Office2010Blue,
+                0 => PaletteMode.Microsoft365Blue,
+                1 => PaletteMode.ProfessionalSystem,
+                2 => PaletteMode.Office2007Black,
+                3 => PaletteMode.Office2007Silver,
+                4 => PaletteMode.Office2007Blue,
+                5 => PaletteMode.ProfessionalOffice2003,
+                6 => PaletteMode.SparkleBlue,
+                7 => PaletteMode.SparkleOrange,
+                8 => PaletteMode.Office2010Black,
+                9 => PaletteMode.Office2010Silver,
+                10 => PaletteMode.Office2010Blue,
                 _ => kryptonManager.GlobalPaletteMode
             };
         }

--- a/Source/Krypton Toolkit Examples/KryptonHelpIcon Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonHelpIcon Examples/Form1.cs
@@ -20,72 +20,72 @@ namespace KryptonHelpIconExamples
 
         private void Form1_Load(object sender, EventArgs e) => palette365Blue.Checked = true;
 
-        private void ChangePalette(PaletteModeManager mode) => kryptonManager.GlobalPaletteMode = mode;
+        private void ChangePalette(PaletteMode mode) => kryptonManager.GlobalPaletteMode = mode;
 
-        private void paletteProfessional_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.ProfessionalSystem);
+        private void paletteProfessional_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.ProfessionalSystem);
 
-        private void paletteOffice2003_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.ProfessionalOffice2003);
+        private void paletteOffice2003_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.ProfessionalOffice2003);
 
-        private void palette2007Black_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2007Black);
+        private void palette2007Black_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2007Black);
 
-        private void palette2007BlackDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2007BlackDarkMode);
+        private void palette2007BlackDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2007BlackDarkMode);
 
-        private void palette2007Blue_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2007Blue);
+        private void palette2007Blue_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2007Blue);
 
-        private void palette2007BlueDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2007BlueDarkMode);
+        private void palette2007BlueDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2007BlueDarkMode);
 
-        private void palette2007BlueLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2007BlueLightMode);
+        private void palette2007BlueLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2007BlueLightMode);
 
-        private void palette2007Silver_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2007Silver);
+        private void palette2007Silver_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2007Silver);
 
-        private void palette2007SilverDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2007SilverDarkMode);
+        private void palette2007SilverDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2007SilverDarkMode);
 
-        private void palette2007SilverLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2007SilverLightMode);
+        private void palette2007SilverLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2007SilverLightMode);
 
-        private void palette2007White_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2007White);
+        private void palette2007White_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2007White);
 
-        private void palette2010Black_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2010Black);
+        private void palette2010Black_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2010Black);
 
-        private void palette2010BlackDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2010BlackDarkMode);
+        private void palette2010BlackDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2010BlackDarkMode);
 
-        private void palette2010Blue_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2010Blue);
+        private void palette2010Blue_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2010Blue);
 
-        private void palette2010BlueDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2010BlueDarkMode);
+        private void palette2010BlueDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2010BlueDarkMode);
 
-        private void palette2010BlueLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2010BlueLightMode);
+        private void palette2010BlueLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2010BlueLightMode);
 
-        private void palette2010Silver_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2010Silver);
+        private void palette2010Silver_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2010Silver);
 
-        private void palette2010SilverDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2010SilverDarkMode);
+        private void palette2010SilverDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2010SilverDarkMode);
 
-        private void palette2010SilverLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2010SilverLightMode);
+        private void palette2010SilverLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2010SilverLightMode);
 
-        private void palette2010White_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2010White);
+        private void palette2010White_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2010White);
 
-        private void paletteOffice2013White_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Office2013White);
+        private void paletteOffice2013White_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Office2013White);
 
-        private void palette365Black_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Microsoft365Black);
+        private void palette365Black_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Microsoft365Black);
 
-        private void palette365BlackDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Microsoft365BlackDarkMode);
+        private void palette365BlackDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Microsoft365BlackDarkMode);
 
-        private void palette365Blue_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Microsoft365Blue);
+        private void palette365Blue_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Microsoft365Blue);
 
-        private void palette365BlueDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Microsoft365BlueDarkMode);
+        private void palette365BlueDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Microsoft365BlueDarkMode);
 
-        private void palette365BlueLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Microsoft365BlueLightMode);
+        private void palette365BlueLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Microsoft365BlueLightMode);
 
-        private void palette365Silver_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Microsoft365Silver);
+        private void palette365Silver_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Microsoft365Silver);
 
-        private void palette365SilverDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Microsoft365SilverDarkMode);
+        private void palette365SilverDarkMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Microsoft365SilverDarkMode);
 
-        private void palette365SilverLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Microsoft365SilverLightMode);
+        private void palette365SilverLightMode_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Microsoft365SilverLightMode);
 
-        private void palette365White_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.Microsoft365White);
+        private void palette365White_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.Microsoft365White);
 
-        private void paletteSparkleBlue_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.SparkleBlue);
+        private void paletteSparkleBlue_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.SparkleBlue);
 
-        private void paletteSparkleOrange_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.SparkleOrange);
+        private void paletteSparkleOrange_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.SparkleOrange);
 
-        private void paletteSparklePurple_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteModeManager.SparklePurple);
+        private void paletteSparklePurple_CheckedChanged(object sender, EventArgs e) => ChangePalette(PaletteMode.SparklePurple);
     }
 }

--- a/Source/Krypton Toolkit Examples/KryptonInputBox Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonInputBox Examples/Form1.Designer.cs
@@ -212,7 +212,7 @@ namespace KryptonInputBoxExamples
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // Form1
             // 

--- a/Source/Krypton Toolkit Examples/KryptonLabel Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonLabel Examples/Form1.Designer.cs
@@ -344,7 +344,7 @@ namespace KryptonLabelExamples
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // kryptonPanel2
             // 

--- a/Source/Krypton Toolkit Examples/KryptonLinkLabel Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonLinkLabel Examples/Form1.Designer.cs
@@ -269,7 +269,7 @@ namespace KryptonLinkLabelExamples
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // Form1
             // 

--- a/Source/Krypton Toolkit Examples/KryptonListBox Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonListBox Examples/Form1.Designer.cs
@@ -220,7 +220,7 @@ namespace KryptonListBoxExamples
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2010Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Blue;
             // 
             // Form1
             // 

--- a/Source/Krypton Toolkit Examples/KryptonListBox Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonListBox Examples/Form1.cs
@@ -104,19 +104,19 @@ namespace KryptonListBoxExamples
         {
             if (kryptonCheckSet.CheckedButton == check2007Blue)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Blue;
             }
             else if (kryptonCheckSet.CheckedButton == check2010Blue)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Blue;
             }
             else if (kryptonCheckSet.CheckedButton == checkSparkle)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.SparkleBlue;
             }
             else if (kryptonCheckSet.CheckedButton == checkSystem)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
             }
         }
 

--- a/Source/Krypton Toolkit Examples/KryptonListView Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonListView Examples/Form1.Designer.cs
@@ -319,7 +319,7 @@ namespace KryptonListViewExamples
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2010Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Blue;
             // 
             // Form1
             // 

--- a/Source/Krypton Toolkit Examples/KryptonMessageBox Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonMessageBox Examples/Form1.Designer.cs
@@ -185,7 +185,7 @@
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2010Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Blue;
             // 
             // kryptonGroupBox1
             // 

--- a/Source/Krypton Toolkit Examples/KryptonMonthCalendar Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonMonthCalendar Examples/Form1.Designer.cs
@@ -251,7 +251,7 @@
             // kryptonManager1
             // 
             this.kryptonManager1.GlobalPalette = this.kryptonPalette;
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Custom;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Custom;
             // 
             // Form1
             // 

--- a/Source/Krypton Toolkit Examples/KryptonNumericUpDown Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonNumericUpDown Examples/Form1.Designer.cs
@@ -206,7 +206,7 @@
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // nud5
             // 

--- a/Source/Krypton Toolkit Examples/KryptonNumericUpDown Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonNumericUpDown Examples/Form1.cs
@@ -30,13 +30,13 @@ namespace KryptonNumericUpDownExamples
             // Setup the property grid to edit this numeric up-down control
             propertyGrid.SelectedObject = new KryptonNumericUpDownProxy(sender as KryptonNumericUpDown);
 
-        private void buttonOffice2010Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+        private void buttonOffice2010Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Blue;
 
-        private void buttonOffice2007Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+        private void buttonOffice2007Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Blue;
 
-        private void buttonSystem_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+        private void buttonSystem_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
 
-        private void buttonSparkleBlue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+        private void buttonSparkleBlue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.SparkleBlue;
 
         private void buttonSpecAny1_Click(object sender, EventArgs e) => nud5.Value = nud5.Minimum;
 

--- a/Source/Krypton Toolkit Examples/KryptonPalette Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonPalette Examples/Form1.Designer.cs
@@ -877,7 +877,7 @@ namespace KryptonPaletteExamples
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // kryptonPaletteOffice2007Blue
             // 

--- a/Source/Krypton Toolkit Examples/KryptonPalette Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonPalette Examples/Form1.cs
@@ -144,7 +144,7 @@ namespace KryptonPaletteExamples
 
                 kryptonManager.GlobalPalette = kryptonPaletteCustom;
 
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Custom;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Custom;
             }
             catch //(Exception exc)
             {

--- a/Source/Krypton Toolkit Examples/KryptonPrintDialog Example/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonPrintDialog Example/Form1.cs
@@ -9,17 +9,17 @@ namespace KryptonFontDialog_Example_2019
     {
         public Form1() => InitializeComponent();
 
-        private void Palette2010Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+        private void Palette2010Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
 
-        private void Palette2010Silver_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+        private void Palette2010Silver_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
 
-        private void Palette2010Black_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+        private void Palette2010Black_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
 
-        private void Palette2007Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+        private void Palette2007Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
 
-        private void PaletteSparkleOrange_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+        private void PaletteSparkleOrange_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
 
-        private void PaletteProfessional_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+        private void PaletteProfessional_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
 
  
         private void ButtonShowFontDialog_Click(object sender, EventArgs e)

--- a/Source/Krypton Toolkit Examples/KryptonSeparator Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonSeparator Examples/Form1.Designer.cs
@@ -324,7 +324,7 @@
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // groupBox4
             // 

--- a/Source/Krypton Toolkit Examples/KryptonSeparator Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonSeparator Examples/Form1.cs
@@ -63,23 +63,23 @@ namespace KryptonSeparatorExamples
             richTextBox1.Text = str + "\n" + newText;
         }
 
-        private void office2010Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+        private void office2010Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Blue;
 
-        private void office2010Silver_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+        private void office2010Silver_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Silver;
 
-        private void office2010Black_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+        private void office2010Black_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Black;
 
-        private void office2007Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+        private void office2007Blue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Blue;
 
-        private void office2007Silver_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+        private void office2007Silver_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Silver;
 
-        private void office2007Black_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+        private void office2007Black_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Black;
 
-        private void sparkleBlue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+        private void sparkleBlue_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.SparkleBlue;
 
-        private void office2003_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+        private void office2003_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
 
-        private void system_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+        private void system_Click(object sender, EventArgs e) => kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
 
         private void buttonClose_Click(object sender, EventArgs e) => Close();
     }

--- a/Source/Krypton Toolkit Examples/KryptonTaskDialog Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonTaskDialog Examples/Form1.Designer.cs
@@ -203,7 +203,7 @@
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2010Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Blue;
             // 
             // checkBoxOK
             // 

--- a/Source/Krypton Toolkit Examples/KryptonTaskDialog Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonTaskDialog Examples/Form1.cs
@@ -27,17 +27,17 @@ namespace KryptonTaskDialogExamples
             comboBoxFooterIcon.Text = "Warning";
         }
 
-        private void palette2010Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+        private void palette2010Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
 
-        private void palette2010Silver_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+        private void palette2010Silver_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
 
-        private void palette2010Black_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+        private void palette2010Black_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
 
-        private void palette2007Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+        private void palette2007Blue_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
 
-        private void paletteSparkleOrange_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+        private void paletteSparkleOrange_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
 
-        private void paletteProfessional_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+        private void paletteProfessional_CheckedChanged(object sender, EventArgs e) => kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
 
         private void buttonShowTaskDialog_Click(object sender, EventArgs e)
         {

--- a/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Form1.Designer.cs
@@ -366,7 +366,7 @@
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2010Blue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Blue;
             // 
             // kryptonCheckSet
             // 

--- a/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonTreeView Examples/Form1.cs
@@ -96,19 +96,19 @@ namespace KryptonTreeViewExamples
         {
             if (kryptonCheckSet.CheckedButton == check2007Blue)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.Office2007Blue;
             }
             else if (kryptonCheckSet.CheckedButton == check2010Blue)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.Office2010Blue;
             }
             else if (kryptonCheckSet.CheckedButton == checkSparkle)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.SparkleBlue;
             }
             else if (kryptonCheckSet.CheckedButton == checkSystem)
             {
-                kryptonManager1.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager1.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
             }
         }
 

--- a/Source/Krypton Toolkit Examples/KryptonWebBrowser Example/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonWebBrowser Example/Form1.Designer.cs
@@ -145,7 +145,7 @@ namespace KryptonWebBrowserExample
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.SparkleBlue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.SparkleBlue;
             // 
             // tableLayoutPanel1
             // 

--- a/Source/Krypton Toolkit Examples/KryptonWebBrowser Example/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonWebBrowser Example/Form1.cs
@@ -16,7 +16,7 @@ namespace KryptonWebBrowserExample
             webBrowser2.DocumentText = @"<div contenteditable=""true"">Krypton WebBrowser.<br/> This is in Editable mode with a Krypton context menu</div>";
 
             ThemeManager.PropagateThemeSelector(kcmbTheme);
-            kcmbTheme.Text = ThemeManager.ReturnPaletteModeManagerAsString(kryptonManager1.GlobalPaletteMode);
+            kcmbTheme.Text = ThemeManager.ReturnPaletteModeAsString(kryptonManager1.GlobalPaletteMode);
         }
 
         private void KcmbTheme_SelectedValueChanged(object sender, System.EventArgs e) => ThemeManager.SetTheme(kcmbTheme.Text, kryptonManager1);

--- a/Source/Krypton Toolkit Examples/MDI Application/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/MDI Application/Form1.Designer.cs
@@ -251,7 +251,7 @@ namespace MDIApplication
             // 
             // kryptonManager1
             // 
-            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.SparkleBlue;
+            this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.SparkleBlue;
             // 
             // Form1
             // 

--- a/Source/Krypton Toolkit Examples/MDI Application/Form2.Designer.cs
+++ b/Source/Krypton Toolkit Examples/MDI Application/Form2.Designer.cs
@@ -188,7 +188,7 @@ namespace MDIApplication
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.SparkleBlue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.SparkleBlue;
             // 
             // Form2
             // 

--- a/Source/Krypton Toolkit Examples/MDI Application/Form2.cs
+++ b/Source/Krypton Toolkit Examples/MDI Application/Form2.cs
@@ -45,7 +45,7 @@ namespace MDIApplication
         {
             if (radio2010Blue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
             }
         }
 
@@ -53,7 +53,7 @@ namespace MDIApplication
         {
             if (radio2010Silver.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
             }
         }
 
@@ -61,7 +61,7 @@ namespace MDIApplication
         {
             if (radio2010Black.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
             }
         }
 
@@ -69,7 +69,7 @@ namespace MDIApplication
         {
             if (radio2007Blue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
             }
         }
 
@@ -77,7 +77,7 @@ namespace MDIApplication
         {
             if (radio2007Silver.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
             }
         }
 
@@ -85,7 +85,7 @@ namespace MDIApplication
         {
             if (radio2007Black.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
             }
         }
 
@@ -93,7 +93,7 @@ namespace MDIApplication
         {
             if (radioSparkleBlue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
             }
         }
 
@@ -101,7 +101,7 @@ namespace MDIApplication
         {
             if (radioSparkleOrange.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
             }
         }
 
@@ -109,7 +109,7 @@ namespace MDIApplication
         {
             if (radioSparklePurple.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparklePurple;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparklePurple;
             }
         }
 
@@ -117,7 +117,7 @@ namespace MDIApplication
         {
             if (radioOffice2003.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
             }
         }
 
@@ -125,7 +125,7 @@ namespace MDIApplication
         {
             if (radioSystem.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
             }
         }
 
@@ -137,37 +137,37 @@ namespace MDIApplication
         {
             switch (kryptonManager.GlobalPaletteMode)
             {
-                case PaletteModeManager.Office2010Blue:
+                case PaletteMode.Office2010Blue:
                     radio2010Blue.Checked = true;
                     break;
-                case PaletteModeManager.Office2010Silver:
+                case PaletteMode.Office2010Silver:
                     radio2010Silver.Checked = true;
                     break;
-                case PaletteModeManager.Office2010Black:
+                case PaletteMode.Office2010Black:
                     radio2010Black.Checked = true;
                     break;
-                case PaletteModeManager.Office2007Blue:
+                case PaletteMode.Office2007Blue:
                     radio2007Blue.Checked = true;
                     break;
-                case PaletteModeManager.Office2007Silver:
+                case PaletteMode.Office2007Silver:
                     radio2007Silver.Checked = true;
                     break;
-                case PaletteModeManager.Office2007Black:
+                case PaletteMode.Office2007Black:
                     radio2007Black.Checked = true;
                     break;
-                case PaletteModeManager.SparkleBlue:
+                case PaletteMode.SparkleBlue:
                     radioSparkleBlue.Checked = true;
                     break;
-                case PaletteModeManager.SparkleOrange:
+                case PaletteMode.SparkleOrange:
                     radioSparkleOrange.Checked = true;
                     break;
-                case PaletteModeManager.SparklePurple:
+                case PaletteMode.SparklePurple:
                     radioSparklePurple.Checked = true;
                     break;
-                case PaletteModeManager.ProfessionalOffice2003:
+                case PaletteMode.ProfessionalOffice2003:
                     radioOffice2003.Checked = true;
                     break;
-                case PaletteModeManager.ProfessionalSystem:
+                case PaletteMode.ProfessionalSystem:
                     radioSystem.Checked = true;
                     break;
             }

--- a/Source/Krypton Toolkit Examples/README.md
+++ b/Source/Krypton Toolkit Examples/README.md
@@ -10,7 +10,7 @@
 	* [Expanding HeaderGroups (Stack)](#expanding-headergroups-stack)
 	* [Input Form](#input-form)
 	* [Krypton Scrollbars](#krypton-scrollbars)
-	* [Krypton Theme Selector](#krypton-theme_selector)
+	* [Krypton Theme Selector](#krypton-theme-selector)
 	* [KryptonBorderEdge Examples](#kryptonborderedge-examples)
 	* [[KryptonBreadCrumb Examples](#kryptonbreadcrumb-examples)
 	* [KryptonButton Examples](#kryptonbutton-examples)

--- a/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Form1.Designer.cs
@@ -288,7 +288,7 @@
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2010Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2010Blue;
             // 
             // kryptonPaletteCustom
             // 

--- a/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Form1.cs
@@ -30,7 +30,7 @@ namespace TestMessageBoxClipping
         {
             if (kryptonOffice2010Silver.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
             }
         }
 
@@ -38,7 +38,7 @@ namespace TestMessageBoxClipping
         {
             if (kryptonOffice2010Black.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
             }
         }
 
@@ -46,7 +46,7 @@ namespace TestMessageBoxClipping
         {
             if (kryptonOffice2007Blue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
             }
         }
 
@@ -54,7 +54,7 @@ namespace TestMessageBoxClipping
         {
             if (kryptonOffice2007Silver.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
             }
         }
 
@@ -62,7 +62,7 @@ namespace TestMessageBoxClipping
         {
             if (kryptonOffice2007Black.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
             }
         }
 
@@ -70,7 +70,7 @@ namespace TestMessageBoxClipping
         {
             if (kryptonSparkleBlue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
             }
         }
 
@@ -78,7 +78,7 @@ namespace TestMessageBoxClipping
         {
             if (kryptonSparkleOrange.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
             }
         }
 
@@ -86,7 +86,7 @@ namespace TestMessageBoxClipping
         {
             if (kryptonSparklePurple.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparklePurple;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparklePurple;
             }
         }
 
@@ -94,7 +94,7 @@ namespace TestMessageBoxClipping
         {
             if (kryptonOffice2003.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
             }
         }
 
@@ -102,7 +102,7 @@ namespace TestMessageBoxClipping
         {
             if (kryptonSystem.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
             }
         }
 
@@ -118,7 +118,7 @@ namespace TestMessageBoxClipping
         {
             if (kryptonOffice2013White.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2013White;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2013White;
             }
         }
 

--- a/Source/Krypton Toolkit Examples/Test Text Clipping/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Test Text Clipping/Form1.Designer.cs
@@ -563,7 +563,7 @@ namespace TestTextClipping
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // kryptonPaletteCustom
             // 

--- a/Source/Krypton Toolkit Examples/Test Text Clipping/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Test Text Clipping/Form1.cs
@@ -18,7 +18,7 @@ namespace TestTextClipping
         {
             if (kryptonOffice2010Blue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
             }
         }
 
@@ -26,7 +26,7 @@ namespace TestTextClipping
         {
             if (kryptonOffice2010Silver.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
             }
         }
 
@@ -34,7 +34,7 @@ namespace TestTextClipping
         {
             if (kryptonOffice2010Black.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
             }
         }
 
@@ -42,7 +42,7 @@ namespace TestTextClipping
         {
             if (kryptonOffice2007Blue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
             }
         }
 
@@ -50,7 +50,7 @@ namespace TestTextClipping
         {
             if (kryptonOffice2007Silver.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
             }
         }
 
@@ -58,7 +58,7 @@ namespace TestTextClipping
         {
             if (kryptonOffice2007Black.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
             }
         }
 
@@ -66,7 +66,7 @@ namespace TestTextClipping
         {
             if (kryptonOffice2003.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
             }
         }
 
@@ -74,7 +74,7 @@ namespace TestTextClipping
         {
             if (kryptonSystem.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
             }
         }
 
@@ -82,7 +82,7 @@ namespace TestTextClipping
         {
             if (kryptonSparkleBlue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
             }
         }
 
@@ -90,7 +90,7 @@ namespace TestTextClipping
         {
             if (kryptonSparkleOrange.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
             }
         }
 
@@ -98,7 +98,7 @@ namespace TestTextClipping
         {
             if (kryptonSparklePurple.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparklePurple;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparklePurple;
             }
         }
 
@@ -118,7 +118,7 @@ namespace TestTextClipping
         {
             if (kryptonOffice2013White.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2013White;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2013White;
             }
         }
 

--- a/Source/Krypton Toolkit Examples/Three Pane Application (Basic)/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Three Pane Application (Basic)/Form1.Designer.cs
@@ -730,7 +730,7 @@ namespace ThreePaneApplication
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // kryptonPaletteCustom
             // 

--- a/Source/Krypton Toolkit Examples/Three Pane Application (Basic)/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Three Pane Application (Basic)/Form1.cs
@@ -23,7 +23,7 @@ namespace ThreePaneApplication
         {
             if (kryptonOffice2010Blue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
             }
         }
 
@@ -31,7 +31,7 @@ namespace ThreePaneApplication
         {
             if (kryptonOffice2010Silver.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
             }
         }
 
@@ -39,7 +39,7 @@ namespace ThreePaneApplication
         {
             if (kryptonOffice2010Black.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
             }
         }
 
@@ -47,7 +47,7 @@ namespace ThreePaneApplication
         {
             if (kryptonOffice2007Blue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
             }
         }
 
@@ -55,7 +55,7 @@ namespace ThreePaneApplication
         {
             if (kryptonOffice2007Silver.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
             }
         }
 
@@ -63,7 +63,7 @@ namespace ThreePaneApplication
         {
             if (kryptonOffice2007Black.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
             }
         }
 
@@ -71,7 +71,7 @@ namespace ThreePaneApplication
         {
             if (kryptonOffice2003.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalOffice2003;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalOffice2003;
             }
         }
 
@@ -79,7 +79,7 @@ namespace ThreePaneApplication
         {
             if (kryptonSystem.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
             }
         }
 
@@ -87,7 +87,7 @@ namespace ThreePaneApplication
         {
             if (kryptonSparkleBlue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
             }
         }
 
@@ -95,7 +95,7 @@ namespace ThreePaneApplication
         {
             if (kryptonSparkleOrange.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
             }
         }
 
@@ -103,7 +103,7 @@ namespace ThreePaneApplication
         {
             if (kryptonSparklePurple.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparklePurple;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparklePurple;
             }
         }
 
@@ -119,7 +119,7 @@ namespace ThreePaneApplication
         {
             if (kryptonOffice2013White.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2013White;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2013White;
             }
         }
     }

--- a/Source/Krypton Toolkit Examples/Three Pane Application (Extended)/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/Three Pane Application (Extended)/Form1.Designer.cs
@@ -947,7 +947,7 @@ namespace ThreePaneApplication
             // 
             // kryptonManager
             // 
-            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteModeManager.Office2007Blue;
+            this.kryptonManager.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
             // 
             // kryptonPaletteCustom
             // 

--- a/Source/Krypton Toolkit Examples/Three Pane Application (Extended)/Form1.cs
+++ b/Source/Krypton Toolkit Examples/Three Pane Application (Extended)/Form1.cs
@@ -72,7 +72,7 @@ namespace ThreePaneApplication
         {
             if (!toolStripOffice2010Blue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Blue;
                 toolStripOffice2010Blue.Checked = office2010BlueToolStripMenuItem.Checked = true;
                 toolStripOffice2010Silver.Checked = office2010SilverToolStripMenuItem.Checked = false;
                 toolStripOffice2010Black.Checked = office2010BlackToolStripMenuItem.Checked = false;
@@ -92,7 +92,7 @@ namespace ThreePaneApplication
         {
             if (!toolStripOffice2010Silver.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Silver;
                 toolStripOffice2010Blue.Checked = office2010BlueToolStripMenuItem.Checked = false;
                 toolStripOffice2010Silver.Checked = office2010SilverToolStripMenuItem.Checked = true;
                 toolStripOffice2010Black.Checked = office2010BlackToolStripMenuItem.Checked = false;
@@ -112,7 +112,7 @@ namespace ThreePaneApplication
         {
             if (!toolStripOffice2010Black.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2010Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2010Black;
                 toolStripOffice2010Blue.Checked = office2010BlueToolStripMenuItem.Checked = false;
                 toolStripOffice2010Silver.Checked = office2010SilverToolStripMenuItem.Checked = false;
                 toolStripOffice2010Black.Checked = office2010BlackToolStripMenuItem.Checked = true;
@@ -132,7 +132,7 @@ namespace ThreePaneApplication
         {
             if (!toolStripOffice2007Blue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Blue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Blue;
                 toolStripOffice2010Blue.Checked = office2010BlueToolStripMenuItem.Checked = false;
                 toolStripOffice2010Silver.Checked = office2010SilverToolStripMenuItem.Checked = false;
                 toolStripOffice2010Black.Checked = office2010BlackToolStripMenuItem.Checked = false;
@@ -152,7 +152,7 @@ namespace ThreePaneApplication
         {
             if (!toolStripOffice2007Silver.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Silver;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Silver;
                 toolStripOffice2010Blue.Checked = office2010BlueToolStripMenuItem.Checked = false;
                 toolStripOffice2010Silver.Checked = office2010SilverToolStripMenuItem.Checked = false;
                 toolStripOffice2010Black.Checked = office2010BlackToolStripMenuItem.Checked = false;
@@ -172,7 +172,7 @@ namespace ThreePaneApplication
         {
             if (!toolStripOffice2007Black.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.Office2007Black;
+                kryptonManager.GlobalPaletteMode = PaletteMode.Office2007Black;
                 toolStripOffice2010Blue.Checked = office2010BlueToolStripMenuItem.Checked = false;
                 toolStripOffice2010Silver.Checked = office2010SilverToolStripMenuItem.Checked = false;
                 toolStripOffice2010Black.Checked = office2010BlackToolStripMenuItem.Checked = false;
@@ -192,7 +192,7 @@ namespace ThreePaneApplication
         {
             if (!toolStripSparkleBlue.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleBlue;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleBlue;
                 toolStripOffice2010Blue.Checked = office2010BlueToolStripMenuItem.Checked = false;
                 toolStripOffice2010Silver.Checked = office2010SilverToolStripMenuItem.Checked = false;
                 toolStripOffice2010Black.Checked = office2010BlackToolStripMenuItem.Checked = false;
@@ -212,7 +212,7 @@ namespace ThreePaneApplication
         {
             if (!toolStripSparkleOrange.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparkleOrange;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparkleOrange;
                 toolStripOffice2010Blue.Checked = office2010BlueToolStripMenuItem.Checked = false;
                 toolStripOffice2010Silver.Checked = office2010SilverToolStripMenuItem.Checked = false;
                 toolStripOffice2010Black.Checked = office2010BlackToolStripMenuItem.Checked = false;
@@ -232,7 +232,7 @@ namespace ThreePaneApplication
         {
             if (!toolStripSparklePurple.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.SparklePurple;
+                kryptonManager.GlobalPaletteMode = PaletteMode.SparklePurple;
                 toolStripOffice2010Blue.Checked = office2010BlueToolStripMenuItem.Checked = false;
                 toolStripOffice2010Silver.Checked = office2010SilverToolStripMenuItem.Checked = false;
                 toolStripOffice2010Black.Checked = office2010BlackToolStripMenuItem.Checked = false;
@@ -252,7 +252,7 @@ namespace ThreePaneApplication
         {
             if (!toolStripSystem.Checked)
             {
-                kryptonManager.GlobalPaletteMode = PaletteModeManager.ProfessionalSystem;
+                kryptonManager.GlobalPaletteMode = PaletteMode.ProfessionalSystem;
                 toolStripOffice2010Blue.Checked = office2010BlueToolStripMenuItem.Checked = false;
                 toolStripOffice2010Silver.Checked = office2010SilverToolStripMenuItem.Checked = false;
                 toolStripOffice2010Black.Checked = office2010BlackToolStripMenuItem.Checked = false;

--- a/Source/Krypton Workspace Examples/Memo Editor/Form1.Designer.cs
+++ b/Source/Krypton Workspace Examples/Memo Editor/Form1.Designer.cs
@@ -427,21 +427,21 @@
             // 
             this.button2010Blue.ButtonType = Krypton.Ribbon.GroupButtonType.Check;
             this.button2010Blue.Checked = true;
-            this.button2010Blue.Tag = "Office2010Blue";
+            this.button2010Blue.Tag = "Office 2010 - Blue";
             this.button2010Blue.TextLine1 = "2010 Blue";
             this.button2010Blue.Click += new System.EventHandler(this.buttonPalette_Clicked);
             // 
             // button2010Silver
             // 
             this.button2010Silver.ButtonType = Krypton.Ribbon.GroupButtonType.Check;
-            this.button2010Silver.Tag = "Office2010Silver";
+            this.button2010Silver.Tag = "Office 2010 - Silver";
             this.button2010Silver.TextLine1 = "2010 Silver";
             this.button2010Silver.Click += new System.EventHandler(this.buttonPalette_Clicked);
             // 
             // button2010Black
             // 
             this.button2010Black.ButtonType = Krypton.Ribbon.GroupButtonType.Check;
-            this.button2010Black.Tag = "Office2010Black";
+            this.button2010Black.Tag = "Office 2010 - Black";
             this.button2010Black.TextLine1 = "2010 Black";
             this.button2010Black.Click += new System.EventHandler(this.buttonPalette_Clicked);
             // 
@@ -459,7 +459,7 @@
             // 
             this.button2007Blue.ButtonType = Krypton.Ribbon.GroupButtonType.Check;
             this.button2007Blue.KeyTip = "2B";
-            this.button2007Blue.Tag = "Office2007Blue";
+            this.button2007Blue.Tag = "Office 2007 - Blue";
             this.button2007Blue.TextLine1 = "2007";
             this.button2007Blue.TextLine2 = "Blue";
             this.button2007Blue.Click += new System.EventHandler(this.buttonPalette_Clicked);
@@ -468,7 +468,7 @@
             // 
             this.button2007Silver.ButtonType = Krypton.Ribbon.GroupButtonType.Check;
             this.button2007Silver.KeyTip = "2S";
-            this.button2007Silver.Tag = "Office2007Silver";
+            this.button2007Silver.Tag = "Office 2007 - Silver";
             this.button2007Silver.TextLine1 = "2007";
             this.button2007Silver.TextLine2 = "Silver";
             this.button2007Silver.Click += new System.EventHandler(this.buttonPalette_Clicked);
@@ -477,7 +477,7 @@
             // 
             this.button2007Black.ButtonType = Krypton.Ribbon.GroupButtonType.Check;
             this.button2007Black.KeyTip = "2L";
-            this.button2007Black.Tag = "Office2007Black";
+            this.button2007Black.Tag = "Office 2007 - Black";
             this.button2007Black.TextLine1 = "2007";
             this.button2007Black.TextLine2 = "Black";
             this.button2007Black.Click += new System.EventHandler(this.buttonPalette_Clicked);
@@ -496,7 +496,7 @@
             // 
             this.buttonSparkleBlue.ButtonType = Krypton.Ribbon.GroupButtonType.Check;
             this.buttonSparkleBlue.KeyTip = "SB";
-            this.buttonSparkleBlue.Tag = "SparkleBlue";
+            this.buttonSparkleBlue.Tag = "Sparkle - Blue";
             this.buttonSparkleBlue.TextLine1 = "Sparkle";
             this.buttonSparkleBlue.TextLine2 = "Blue";
             this.buttonSparkleBlue.Click += new System.EventHandler(this.buttonPalette_Clicked);
@@ -505,7 +505,7 @@
             // 
             this.buttonSparkleOrange.ButtonType = Krypton.Ribbon.GroupButtonType.Check;
             this.buttonSparkleOrange.KeyTip = "SO";
-            this.buttonSparkleOrange.Tag = "SparkleOrange";
+            this.buttonSparkleOrange.Tag = "Sparkle - Orange";
             this.buttonSparkleOrange.TextLine1 = "Sparkle";
             this.buttonSparkleOrange.TextLine2 = "Orange";
             this.buttonSparkleOrange.Click += new System.EventHandler(this.buttonPalette_Clicked);
@@ -513,8 +513,8 @@
             // buttonSparklePurple
             // 
             this.buttonSparklePurple.ButtonType = Krypton.Ribbon.GroupButtonType.Check;
-            this.buttonSparklePurple.KeyTip = "SO";
-            this.buttonSparklePurple.Tag = "SparklePurple";
+            this.buttonSparklePurple.KeyTip = "SP";
+            this.buttonSparklePurple.Tag = "Sparkle - Purple";
             this.buttonSparklePurple.TextLine1 = "Sparkle";
             this.buttonSparklePurple.TextLine2 = "Purple";
             this.buttonSparklePurple.Click += new System.EventHandler(this.buttonPalette_Clicked);
@@ -532,7 +532,7 @@
             // 
             this.buttonSystem.ButtonType = Krypton.Ribbon.GroupButtonType.Check;
             this.buttonSystem.KeyTip = "Y";
-            this.buttonSystem.Tag = "ProfessionalSystem";
+            this.buttonSystem.Tag = "Professional - System";
             this.buttonSystem.TextLine1 = "System";
             this.buttonSystem.Click += new System.EventHandler(this.buttonPalette_Clicked);
             // 
@@ -540,7 +540,7 @@
             // 
             this.button2003.ButtonType = Krypton.Ribbon.GroupButtonType.Check;
             this.button2003.KeyTip = "3";
-            this.button2003.Tag = "ProfessionalOffice2003";
+            this.button2003.Tag = "Professional - Office 2003";
             this.button2003.TextLine1 = "2003";
             this.button2003.Click += new System.EventHandler(this.buttonPalette_Clicked);
             // 
@@ -685,7 +685,6 @@
             this.ClientSize = new System.Drawing.Size(584, 464);
             this.Controls.Add(this.kryptonPanel1);
             this.Controls.Add(this.kryptonRibbon);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MinimumSize = new System.Drawing.Size(489, 414);
             this.Name = "MemoEditorForm";
             this.Text = "Memo Editor";

--- a/Source/Krypton Workspace Examples/Memo Editor/Form1.cs
+++ b/Source/Krypton Workspace Examples/Memo Editor/Form1.cs
@@ -349,7 +349,7 @@ namespace MemoEditor
         {
             // The tag property of the button is the enum string value of the palette we want
             KryptonRibbonGroupButton button = (KryptonRibbonGroupButton)sender;
-            kryptonManager.GlobalPaletteMode = (PaletteModeManager)Enum.Parse(typeof(PaletteModeManager), (string)button.Tag);
+            kryptonManager.GlobalPaletteMode = ThemeManager.GetThemeManagerMode((string)button.Tag);
             UpdateButtonsFromPalette();
         }
 


### PR DESCRIPTION
- Fix fallout from type removal
- Now a single set of strings for the theme names

#https://github.com/Krypton-Suite/Standard-Toolkit/issues/827