### PR TITLE
- **Breaking Change** KryptonMessageBox does not obey tab characters …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,4 +356,4 @@ Source/Krypton Toolkit Examples/Temp.txt
 *.msi
 *.wixpdb
 Source/Krypton Ribbon Examples/Temp.txt
-/Binaries/Krypton Demos/Release*
+/Binaries/Krypton Demos

--- a/Source/Krypton Toolkit Examples/KryptonMessageBox Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonMessageBox Examples/Form1.Designer.cs
@@ -55,7 +55,6 @@
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
             this.kbtnDummyText = new Krypton.Toolkit.KryptonButton();
             this.kryptonGroupBox2 = new Krypton.Toolkit.KryptonGroupBox();
-            this.kcmbMessageTextAlignment = new Krypton.Toolkit.KryptonComboBox();
             this.kryptonLabel2 = new Krypton.Toolkit.KryptonLabel();
             this.ktxtResourcePath = new Krypton.Toolkit.KryptonTextBox();
             this.bsaBrowse = new Krypton.Toolkit.ButtonSpecAny();
@@ -85,7 +84,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox2.Panel)).BeginInit();
             this.kryptonGroupBox2.Panel.SuspendLayout();
             this.kryptonGroupBox2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.kcmbMessageTextAlignment)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kcmbContentAreaType)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
             this.SuspendLayout();
@@ -347,7 +345,6 @@
             // 
             // kryptonGroupBox2.Panel
             // 
-            this.kryptonGroupBox2.Panel.Controls.Add(this.kcmbMessageTextAlignment);
             this.kryptonGroupBox2.Panel.Controls.Add(this.kryptonLabel2);
             this.kryptonGroupBox2.Panel.Controls.Add(this.ktxtResourcePath);
             this.kryptonGroupBox2.Panel.Controls.Add(this.knudLinkAreaEnd);
@@ -358,19 +355,6 @@
             this.kryptonGroupBox2.Size = new System.Drawing.Size(246, 187);
             this.kryptonGroupBox2.TabIndex = 9;
             this.kryptonGroupBox2.Values.Heading = "Content Area Type";
-            // 
-            // kcmbMessageTextAlignment
-            // 
-            this.kcmbMessageTextAlignment.CueHint.Padding = new System.Windows.Forms.Padding(0);
-            this.kcmbMessageTextAlignment.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.kcmbMessageTextAlignment.DropDownWidth = 215;
-            this.kcmbMessageTextAlignment.IntegralHeight = false;
-            this.kcmbMessageTextAlignment.Location = new System.Drawing.Point(14, 133);
-            this.kcmbMessageTextAlignment.Name = "kcmbMessageTextAlignment";
-            this.kcmbMessageTextAlignment.Size = new System.Drawing.Size(215, 21);
-            this.kcmbMessageTextAlignment.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
-            this.kcmbMessageTextAlignment.TabIndex = 8;
-            this.kcmbMessageTextAlignment.SelectedIndexChanged += new System.EventHandler(this.kcmbMessageTextAlignment_SelectedIndexChanged);
             // 
             // kryptonLabel2
             // 
@@ -566,7 +550,6 @@
             this.kryptonGroupBox2.Panel.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonGroupBox2)).EndInit();
             this.kryptonGroupBox2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.kcmbMessageTextAlignment)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kcmbContentAreaType)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
             this.ResumeLayout(false);
@@ -613,7 +596,6 @@
         private Krypton.Toolkit.KryptonTextBox ktxtResourcePath;
         private Krypton.Toolkit.ButtonSpecAny bsaBrowse;
         private Krypton.Toolkit.KryptonCommand kcmdTest;
-        private Krypton.Toolkit.KryptonComboBox kcmbMessageTextAlignment;
         private Krypton.Toolkit.KryptonLabel kryptonLabel2;
         private Krypton.Toolkit.KryptonButton kbtnDummyText;
     }

--- a/Source/Krypton Toolkit Examples/KryptonMessageBox Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonMessageBox Examples/Form1.cs
@@ -40,7 +40,6 @@ namespace KryptonMessageBoxExamples
         private KryptonMessageBoxButtons _mbButtons = KryptonMessageBoxButtons.OKCancel;
         private MessageBoxOptions _options = 0;
         private MessageBoxContentAreaType _contentAreaType = MessageBoxContentAreaType.Normal;
-        private ContentAlignment _messageTextAlignment = ContentAlignment.MiddleLeft;
 
         public Form1()
         {
@@ -168,8 +167,7 @@ namespace KryptonMessageBoxExamples
                 options: _options,
                 showHelpButton: chkShowHelp.Checked, contentAreaType: _contentAreaType,
                 contentLinkArea: new LinkArea(decimal.ToInt32(knudLinkAreaStart.Value), decimal.ToInt32(knudLinkAreaEnd.Value)),
-                linkAreaCommand: kcmdTest,
-                messageTextAlignment: _messageTextAlignment);
+                linkAreaCommand: kcmdTest);
 
             textBoxMessage.Text = $@"Krypton DialogResult = {res}";
         }
@@ -226,11 +224,6 @@ namespace KryptonMessageBoxExamples
                 kcmbContentAreaType.Items.Add(value);
             }
 
-            foreach (string value in Enum.GetNames(typeof(ContentAlignment)))
-            {
-                kcmbMessageTextAlignment.Items.Add(value);
-            }
-
             knudLinkAreaStart.Maximum = textBoxMessage.Text.Length;
 
             knudLinkAreaEnd.Maximum = textBoxMessage.Text.Length;
@@ -238,8 +231,6 @@ namespace KryptonMessageBoxExamples
             knudLinkAreaEnd.Value = textBoxMessage.Text.Length;
 
             kcmbContentAreaType.SelectedIndex = 0;
-
-            kcmbMessageTextAlignment.SelectedIndex = 3;
         }
 
         private void textBoxMessage_TextChanged(object sender, EventArgs e)
@@ -308,11 +299,6 @@ namespace KryptonMessageBoxExamples
             knudLinkAreaEnd.Enabled = enabled;
 
             ktxtResourcePath.Enabled = enabled;
-        }
-
-        private void kcmbMessageTextAlignment_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            _messageTextAlignment = (ContentAlignment)Enum.Parse(typeof(ContentAlignment), kcmbMessageTextAlignment.Text);
         }
 
         private void kbtnDummyText_Click(object sender, EventArgs e)


### PR DESCRIPTION
…like MessageBox

  -  The optional ContentAlignment for a KryptonMessageBox.Show command is no longer possible.

#https://github.com/Krypton-Suite/Standard-Toolkit/issues/1424