### PR TITLE
244-V95-KryptonVerticalScrollBar-demo-scrollbar-width-height-incorrect

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -2,6 +2,7 @@
 
 
 ## 2025-11-xx - Build 2511 - November
+* Resolved [#244](https://github.com/Krypton-Suite/Standard-Toolkit-Demos/issues/244) KryptonVerticalScrollBar demo scrollbar dimensions incorrect.
 * Resolved [#231](https://github.com/Krypton-Suite/Standard-Toolkit-Demos/issues/231), `Explorer` launch of "Workspace Persistence" causes an exception to be displayed
 * Resolved [#2301](https://github.com/Krypton-Suite/Standard-Toolkit-Demos/issues/230), `Explorer` launch of Workspace example does nothing
 * Resolved [#229](https://github.com/Krypton-Suite/Standard-Toolkit-Demos/issues/229), `Explorer` titles for Navigator no longer apply

--- a/Source/Krypton Toolkit Examples/KryptonScrollbar Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonScrollbar Examples/Form1.Designer.cs
@@ -56,17 +56,15 @@ namespace KryptonScrollbarExamples
             this.kryptonPanel1.Controls.Add(this.ksbVertical);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
-            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(551, 325);
+            this.kryptonPanel1.Size = new System.Drawing.Size(425, 256);
             this.kryptonPanel1.TabIndex = 0;
             // 
             // pbVertical
             // 
-            this.pbVertical.Location = new System.Drawing.Point(52, 204);
-            this.pbVertical.Margin = new System.Windows.Forms.Padding(4);
+            this.pbVertical.Location = new System.Drawing.Point(39, 166);
             this.pbVertical.Name = "pbVertical";
-            this.pbVertical.Size = new System.Drawing.Size(471, 28);
+            this.pbVertical.Size = new System.Drawing.Size(353, 23);
             this.pbVertical.TabIndex = 7;
             // 
             // knudVertical
@@ -76,8 +74,7 @@ namespace KryptonScrollbarExamples
             0,
             0,
             0});
-            this.knudVertical.Location = new System.Drawing.Point(215, 171);
-            this.knudVertical.Margin = new System.Windows.Forms.Padding(4);
+            this.knudVertical.Location = new System.Drawing.Point(161, 139);
             this.knudVertical.Maximum = new decimal(new int[] {
             100,
             0,
@@ -89,7 +86,7 @@ namespace KryptonScrollbarExamples
             0,
             0});
             this.knudVertical.Name = "knudVertical";
-            this.knudVertical.Size = new System.Drawing.Size(160, 26);
+            this.knudVertical.Size = new System.Drawing.Size(120, 22);
             this.knudVertical.TabIndex = 6;
             this.knudVertical.Value = new decimal(new int[] {
             0,
@@ -101,19 +98,17 @@ namespace KryptonScrollbarExamples
             // kryptonLabel2
             // 
             this.kryptonLabel2.LabelStyle = Krypton.Toolkit.LabelStyle.BoldControl;
-            this.kryptonLabel2.Location = new System.Drawing.Point(52, 171);
-            this.kryptonLabel2.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonLabel2.Location = new System.Drawing.Point(39, 139);
             this.kryptonLabel2.Name = "kryptonLabel2";
-            this.kryptonLabel2.Size = new System.Drawing.Size(116, 24);
+            this.kryptonLabel2.Size = new System.Drawing.Size(94, 20);
             this.kryptonLabel2.TabIndex = 5;
             this.kryptonLabel2.Values.Text = "Vertical Value:";
             // 
             // pbHorizontal
             // 
-            this.pbHorizontal.Location = new System.Drawing.Point(52, 81);
-            this.pbHorizontal.Margin = new System.Windows.Forms.Padding(4);
+            this.pbHorizontal.Location = new System.Drawing.Point(39, 66);
             this.pbHorizontal.Name = "pbHorizontal";
-            this.pbHorizontal.Size = new System.Drawing.Size(471, 28);
+            this.pbHorizontal.Size = new System.Drawing.Size(353, 23);
             this.pbHorizontal.TabIndex = 4;
             // 
             // knudHorizontal
@@ -123,8 +118,7 @@ namespace KryptonScrollbarExamples
             0,
             0,
             0});
-            this.knudHorizontal.Location = new System.Drawing.Point(215, 48);
-            this.knudHorizontal.Margin = new System.Windows.Forms.Padding(4);
+            this.knudHorizontal.Location = new System.Drawing.Point(161, 39);
             this.knudHorizontal.Maximum = new decimal(new int[] {
             100,
             0,
@@ -136,7 +130,7 @@ namespace KryptonScrollbarExamples
             0,
             0});
             this.knudHorizontal.Name = "knudHorizontal";
-            this.knudHorizontal.Size = new System.Drawing.Size(160, 26);
+            this.knudHorizontal.Size = new System.Drawing.Size(120, 22);
             this.knudHorizontal.TabIndex = 3;
             this.knudHorizontal.Value = new decimal(new int[] {
             0,
@@ -148,10 +142,9 @@ namespace KryptonScrollbarExamples
             // kryptonLabel1
             // 
             this.kryptonLabel1.LabelStyle = Krypton.Toolkit.LabelStyle.BoldControl;
-            this.kryptonLabel1.Location = new System.Drawing.Point(52, 48);
-            this.kryptonLabel1.Margin = new System.Windows.Forms.Padding(4);
+            this.kryptonLabel1.Location = new System.Drawing.Point(39, 39);
             this.kryptonLabel1.Name = "kryptonLabel1";
-            this.kryptonLabel1.Size = new System.Drawing.Size(137, 24);
+            this.kryptonLabel1.Size = new System.Drawing.Size(111, 20);
             this.kryptonLabel1.TabIndex = 2;
             this.kryptonLabel1.Values.Text = "Horizontal Value:";
             // 
@@ -159,13 +152,12 @@ namespace KryptonScrollbarExamples
             // 
             this.ksbHorizontal.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(93)))), ((int)(((byte)(140)))), ((int)(((byte)(201)))));
             this.ksbHorizontal.DisabledBorderColor = System.Drawing.Color.Gray;
-            this.ksbHorizontal.Location = new System.Drawing.Point(52, 16);
-            this.ksbHorizontal.Margin = new System.Windows.Forms.Padding(4);
+            this.ksbHorizontal.Location = new System.Drawing.Point(39, 13);
             this.ksbHorizontal.Name = "ksbHorizontal";
             this.ksbHorizontal.Opacity = 1D;
             this.ksbHorizontal.Orientation = Krypton.Toolkit.ScrollBarOrientation.Horizontal;
-            this.ksbHorizontal.ScrollBarWidth = 471;
-            this.ksbHorizontal.Size = new System.Drawing.Size(471, 19);
+            this.ksbHorizontal.ScrollBarWidth = 353;
+            this.ksbHorizontal.Size = new System.Drawing.Size(353, 19);
             this.ksbHorizontal.TabIndex = 1;
             this.ksbHorizontal.Scroll += new System.Windows.Forms.ScrollEventHandler(this.ksbHorizontal_Scroll);
             // 
@@ -173,24 +165,22 @@ namespace KryptonScrollbarExamples
             // 
             this.ksbVertical.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(93)))), ((int)(((byte)(140)))), ((int)(((byte)(201)))));
             this.ksbVertical.DisabledBorderColor = System.Drawing.Color.Gray;
-            this.ksbVertical.Location = new System.Drawing.Point(17, 16);
-            this.ksbVertical.Margin = new System.Windows.Forms.Padding(4);
+            this.ksbVertical.Location = new System.Drawing.Point(13, 13);
             this.ksbVertical.Name = "ksbVertical";
             this.ksbVertical.Opacity = 1D;
             this.ksbVertical.ScrollBarWidth = 19;
-            this.ksbVertical.Size = new System.Drawing.Size(19, 304);
+            this.ksbVertical.Size = new System.Drawing.Size(19, 231);
             this.ksbVertical.TabIndex = 0;
             this.ksbVertical.Scroll += new System.Windows.Forms.ScrollEventHandler(this.ksbVertical_Scroll);
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(551, 325);
+            this.ClientSize = new System.Drawing.Size(425, 256);
             this.Controls.Add(this.kryptonPanel1);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.Name = "Form1";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;


### PR DESCRIPTION
[Issue 244-KryptonVerticalScrollBar-demo-scrollbar-width-height-incorrect](https://github.com/Krypton-Suite/Standard-Toolkit-Demos/issues/244)
- Correct scrollbar dimensions to default
- And the change log

Build tested in the IDE.