### PR TITLE
249 v100 KryptonProgressBar Demo Update

### DIFF
--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -2,6 +2,7 @@
 
 
 ## 2025-11-xx - Build 2511 - November
+* Resolved [#249](https://github.com/Krypton-Suite/Standard-Toolkit-Demos/issues/249) 'KryptonProgressBar' demo updated with more options.
 * Removed Krypton OutLookGrid example
 * Implemented Krypton ToggleSwitch example
 * Resolved [#244](https://github.com/Krypton-Suite/Standard-Toolkit-Demos/issues/244) KryptonVerticalScrollBar demo scrollbar dimensions incorrect.

--- a/Source/Krypton Toolkit Examples/KryptonAboutToolkit Example/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonAboutToolkit Example/Form1.cs
@@ -12,13 +12,13 @@ namespace KryptonAboutToolkitExample
 {
     public partial class Form1 : KryptonForm
     {
-        private ToolkitType _toolkitType;
+        private ToolkitSupportType _toolkitType;
 
         public Form1()
         {
             InitializeComponent();
 
-            _toolkitType = ToolkitType.Stable;
+            _toolkitType = ToolkitSupportType.Stable;
         }
 
         private void kbtnCancel_Click(object sender, EventArgs e) => Close();
@@ -69,7 +69,7 @@ namespace KryptonAboutToolkitExample
 
             data.ShowVersionInformationButton = kcbShowVersionInformationButton.Checked;
 
-            data.ToolkitType = _toolkitType;
+            data.ToolkitSupportType = _toolkitType;
 
             data.DiscordLinkArea = new LinkArea((int)knumLinkAreaDiscordStart.Value, (int)knumLinkAreaDiscordEnd.Value);
 
@@ -88,17 +88,17 @@ namespace KryptonAboutToolkitExample
         {
             if (krbCanary.Checked)
             {
-                _toolkitType = ToolkitType.Canary;
+                _toolkitType = ToolkitSupportType.Canary;
             }
 
             if (krbNightly.Checked)
             {
-                _toolkitType = ToolkitType.Nightly;
+                _toolkitType = ToolkitSupportType.Nightly;
             }
 
             if (krbStable.Checked)
             {
-                _toolkitType = ToolkitType.Stable;
+                _toolkitType = ToolkitSupportType.Stable;
             }
         }
     }

--- a/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/Form1.Designer.cs
@@ -1,5 +1,9 @@
-﻿
-namespace KryptonScrollbarExamples
+﻿// *****************************************************************************
+// BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit)
+// By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege 2023 - 2025. All rights reserved.
+// *****************************************************************************
+
+namespace KryptonProgressBarExamples
 {
     partial class Form1
     {
@@ -30,13 +34,25 @@ namespace KryptonScrollbarExamples
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
             this.kryptonPanel1 = new Krypton.Toolkit.KryptonPanel();
-            this.kryptonProgressBar2 = new Krypton.Toolkit.KryptonProgressBar();
+            this.kchkShowTextShadow = new Krypton.Toolkit.KryptonCheckBox();
+            this.kryptonLabel3 = new Krypton.Toolkit.KryptonLabel();
+            this.kcbtnProgressBarColour = new Krypton.Toolkit.KryptonColorButton();
+            this.kcmbProgressBarStyle = new Krypton.Toolkit.KryptonComboBox();
+            this.klblColorStyle = new Krypton.Toolkit.KryptonLabel();
+            this.kcmbColorStyle = new Krypton.Toolkit.KryptonComboBox();
+            this.kchkShowTextBackdrop = new Krypton.Toolkit.KryptonCheckBox();
+            this.kcbtnBackdropColor = new Krypton.Toolkit.KryptonColorButton();
+            this.kchkUseProgressValueAsText = new Krypton.Toolkit.KryptonCheckBox();
+            this.kryptonLabel2 = new Krypton.Toolkit.KryptonLabel();
+            this.ktrkProgressValues = new Krypton.Toolkit.KryptonTrackBar();
+            this.ProgressBarDisabled = new Krypton.Toolkit.KryptonProgressBar();
             this.kryptonButton1 = new Krypton.Toolkit.KryptonButton();
             this.kryptonThemeComboBox1 = new Krypton.Toolkit.KryptonThemeComboBox();
-            this.kryptonProgressBar1 = new Krypton.Toolkit.KryptonProgressBar();
-            this.progressBar1 = new Krypton.Toolkit.KryptonProgressBar();
             this.pbVertical = new Krypton.Toolkit.KryptonProgressBar();
+            this.pbCustomColor = new Krypton.Toolkit.KryptonProgressBar();
+            this.pbHorizontal2 = new Krypton.Toolkit.KryptonProgressBar();
             this.pbHorizontal = new Krypton.Toolkit.KryptonProgressBar();
             this.knudHorizontal = new Krypton.Toolkit.KryptonNumericUpDown();
             this.kryptonLabel1 = new Krypton.Toolkit.KryptonLabel();
@@ -45,52 +61,185 @@ namespace KryptonScrollbarExamples
             this.kryptonProgressBarToolStripItem1 = new Krypton.Toolkit.KryptonProgressBarToolStripItem();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).BeginInit();
             this.kryptonPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbProgressBarStyle)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbColorStyle)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).BeginInit();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
             // kryptonPanel1
             // 
-            this.kryptonPanel1.Controls.Add(this.kryptonProgressBar2);
+            this.kryptonPanel1.Controls.Add(this.kchkShowTextShadow);
+            this.kryptonPanel1.Controls.Add(this.kryptonLabel3);
+            this.kryptonPanel1.Controls.Add(this.kcbtnProgressBarColour);
+            this.kryptonPanel1.Controls.Add(this.kcmbProgressBarStyle);
+            this.kryptonPanel1.Controls.Add(this.klblColorStyle);
+            this.kryptonPanel1.Controls.Add(this.kcmbColorStyle);
+            this.kryptonPanel1.Controls.Add(this.kchkShowTextBackdrop);
+            this.kryptonPanel1.Controls.Add(this.kcbtnBackdropColor);
+            this.kryptonPanel1.Controls.Add(this.kchkUseProgressValueAsText);
+            this.kryptonPanel1.Controls.Add(this.kryptonLabel2);
+            this.kryptonPanel1.Controls.Add(this.ktrkProgressValues);
+            this.kryptonPanel1.Controls.Add(this.ProgressBarDisabled);
             this.kryptonPanel1.Controls.Add(this.kryptonButton1);
             this.kryptonPanel1.Controls.Add(this.kryptonThemeComboBox1);
-            this.kryptonPanel1.Controls.Add(this.kryptonProgressBar1);
-            this.kryptonPanel1.Controls.Add(this.progressBar1);
             this.kryptonPanel1.Controls.Add(this.pbVertical);
+            this.kryptonPanel1.Controls.Add(this.pbCustomColor);
+            this.kryptonPanel1.Controls.Add(this.pbHorizontal2);
             this.kryptonPanel1.Controls.Add(this.pbHorizontal);
             this.kryptonPanel1.Controls.Add(this.knudHorizontal);
             this.kryptonPanel1.Controls.Add(this.kryptonLabel1);
             this.kryptonPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.kryptonPanel1.Location = new System.Drawing.Point(0, 0);
-            this.kryptonPanel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.kryptonPanel1.Name = "kryptonPanel1";
-            this.kryptonPanel1.Size = new System.Drawing.Size(553, 374);
+            this.kryptonPanel1.Size = new System.Drawing.Size(799, 422);
             this.kryptonPanel1.TabIndex = 0;
             // 
-            // kryptonProgressBar2
+            // kchkShowTextShadow
             // 
-            this.kryptonProgressBar2.Enabled = false;
-            this.kryptonProgressBar2.Location = new System.Drawing.Point(52, 250);
-            this.kryptonProgressBar2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.kryptonProgressBar2.Name = "kryptonProgressBar2";
-            this.kryptonProgressBar2.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.kryptonProgressBar2.Size = new System.Drawing.Size(471, 28);
-            this.kryptonProgressBar2.StateCommon.Back.Color1 = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
-            this.kryptonProgressBar2.StateCommon.Border.DrawBorders = ((Krypton.Toolkit.PaletteDrawBorders)((((Krypton.Toolkit.PaletteDrawBorders.Top | Krypton.Toolkit.PaletteDrawBorders.Bottom) 
+            this.kchkShowTextShadow.Location = new System.Drawing.Point(43, 307);
+            this.kchkShowTextShadow.Name = "kchkShowTextShadow";
+            this.kchkShowTextShadow.Size = new System.Drawing.Size(131, 21);
+            this.kchkShowTextShadow.TabIndex = 33;
+            this.kchkShowTextShadow.Values.Text = "Show text shadow";
+            this.kchkShowTextShadow.CheckedChanged += new System.EventHandler(this.kchkShowTextShadow_CheckedChanged);
+            // 
+            // kryptonLabel3
+            // 
+            this.kryptonLabel3.Location = new System.Drawing.Point(262, 239);
+            this.kryptonLabel3.Name = "kryptonLabel3";
+            this.kryptonLabel3.Size = new System.Drawing.Size(94, 21);
+            this.kryptonLabel3.TabIndex = 32;
+            this.kryptonLabel3.Values.Text = "Progress Style";
+            // 
+            // kcbtnProgressBarColour
+            // 
+            this.kcbtnProgressBarColour.CustomColorPreviewShape = Krypton.Toolkit.KryptonColorButtonCustomColorPreviewShape.Circle;
+            this.kcbtnProgressBarColour.Location = new System.Drawing.Point(43, 265);
+            this.kcbtnProgressBarColour.Name = "kcbtnProgressBarColour";
+            this.kcbtnProgressBarColour.SelectedColor = System.Drawing.Color.Green;
+            this.kcbtnProgressBarColour.Size = new System.Drawing.Size(177, 25);
+            this.kcbtnProgressBarColour.TabIndex = 27;
+            this.kcbtnProgressBarColour.Values.Image = ((System.Drawing.Image)(resources.GetObject("kcbtnProgressBarColour.Values.Image")));
+            this.kcbtnProgressBarColour.Values.RoundedCorners = 8;
+            this.kcbtnProgressBarColour.Values.Text = "Custom Color";
+            this.kcbtnProgressBarColour.SelectedColorChanged += new System.EventHandler<Krypton.Toolkit.ColorEventArgs>(this.kcbtnProgressBarColour_SelectedColorChanged);
+            // 
+            // kcmbProgressBarStyle
+            // 
+            this.kcmbProgressBarStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.kcmbProgressBarStyle.DropDownWidth = 261;
+            this.kcmbProgressBarStyle.IntegralHeight = false;
+            this.kcmbProgressBarStyle.Location = new System.Drawing.Point(373, 237);
+            this.kcmbProgressBarStyle.Name = "kcmbProgressBarStyle";
+            this.kcmbProgressBarStyle.Size = new System.Drawing.Size(179, 24);
+            this.kcmbProgressBarStyle.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
+            this.kcmbProgressBarStyle.TabIndex = 26;
+            this.kcmbProgressBarStyle.SelectedIndexChanged += new System.EventHandler(this.kcmbProgressBarStyle_SelectedIndexChanged);
+            // 
+            // klblColorStyle
+            // 
+            this.klblColorStyle.Location = new System.Drawing.Point(262, 266);
+            this.klblColorStyle.Name = "klblColorStyle";
+            this.klblColorStyle.Size = new System.Drawing.Size(75, 21);
+            this.klblColorStyle.TabIndex = 28;
+            this.klblColorStyle.Values.Text = "Color Style";
+            // 
+            // kcmbColorStyle
+            // 
+            this.kcmbColorStyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.kcmbColorStyle.DropDownWidth = 179;
+            this.kcmbColorStyle.IntegralHeight = false;
+            this.kcmbColorStyle.Location = new System.Drawing.Point(373, 265);
+            this.kcmbColorStyle.Name = "kcmbColorStyle";
+            this.kcmbColorStyle.Size = new System.Drawing.Size(179, 24);
+            this.kcmbColorStyle.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
+            this.kcmbColorStyle.TabIndex = 29;
+            this.kcmbColorStyle.SelectedIndexChanged += new System.EventHandler(this.kcmbColorStyle_SelectedIndexChanged);
+            // 
+            // kchkShowTextBackdrop
+            // 
+            this.kchkShowTextBackdrop.Location = new System.Drawing.Point(43, 333);
+            this.kchkShowTextBackdrop.Name = "kchkShowTextBackdrop";
+            this.kchkShowTextBackdrop.Size = new System.Drawing.Size(141, 21);
+            this.kchkShowTextBackdrop.TabIndex = 30;
+            this.kchkShowTextBackdrop.Values.Text = "Show text backdrop";
+            this.kchkShowTextBackdrop.CheckedChanged += new System.EventHandler(this.kchkShowTextBackdrop_CheckedChanged);
+            // 
+            // kcbtnBackdropColor
+            // 
+            this.kcbtnBackdropColor.CustomColorPreviewShape = Krypton.Toolkit.KryptonColorButtonCustomColorPreviewShape.Circle;
+            this.kcbtnBackdropColor.Location = new System.Drawing.Point(43, 359);
+            this.kcbtnBackdropColor.Name = "kcbtnBackdropColor";
+            this.kcbtnBackdropColor.SelectedColor = System.Drawing.Color.WhiteSmoke;
+            this.kcbtnBackdropColor.Size = new System.Drawing.Size(177, 25);
+            this.kcbtnBackdropColor.TabIndex = 31;
+            this.kcbtnBackdropColor.Values.Image = ((System.Drawing.Image)(resources.GetObject("kcbtnBackdropColor.Values.Image")));
+            this.kcbtnBackdropColor.Values.RoundedCorners = 8;
+            this.kcbtnBackdropColor.Values.Text = "Text Backdrop Colour";
+            this.kcbtnBackdropColor.SelectedColorChanged += new System.EventHandler<Krypton.Toolkit.ColorEventArgs>(this.kcbtnBackdropColor_SelectedColorChanged);
+            // 
+            // kchkUseProgressValueAsText
+            // 
+            this.kchkUseProgressValueAsText.Checked = true;
+            this.kchkUseProgressValueAsText.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.kchkUseProgressValueAsText.Location = new System.Drawing.Point(43, 239);
+            this.kchkUseProgressValueAsText.Name = "kchkUseProgressValueAsText";
+            this.kchkUseProgressValueAsText.Size = new System.Drawing.Size(177, 21);
+            this.kchkUseProgressValueAsText.TabIndex = 25;
+            this.kchkUseProgressValueAsText.Values.Text = "Use progress value as text";
+            this.kchkUseProgressValueAsText.CheckedChanged += new System.EventHandler(this.kchkUseProgressValueAsText_CheckedChanged);
+            // 
+            // kryptonLabel2
+            // 
+            this.kryptonLabel2.LabelStyle = Krypton.Toolkit.LabelStyle.BoldPanel;
+            this.kryptonLabel2.Location = new System.Drawing.Point(43, 12);
+            this.kryptonLabel2.Name = "kryptonLabel2";
+            this.kryptonLabel2.Size = new System.Drawing.Size(57, 21);
+            this.kryptonLabel2.TabIndex = 15;
+            this.kryptonLabel2.Values.Text = "Theme:";
+            // 
+            // ktrkProgressValues
+            // 
+            this.ktrkProgressValues.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ktrkProgressValues.Location = new System.Drawing.Point(187, 37);
+            this.ktrkProgressValues.Maximum = 100;
+            this.ktrkProgressValues.Name = "ktrkProgressValues";
+            this.ktrkProgressValues.Size = new System.Drawing.Size(590, 33);
+            this.ktrkProgressValues.TabIndex = 14;
+            this.ktrkProgressValues.TickStyle = System.Windows.Forms.TickStyle.Both;
+            this.ktrkProgressValues.ValueChanged += new System.EventHandler(this.ktrkProgressValues_ValueChanged);
+            // 
+            // ProgressBarDisabled
+            // 
+            this.ProgressBarDisabled.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ProgressBarDisabled.Enabled = false;
+            this.ProgressBarDisabled.Location = new System.Drawing.Point(43, 203);
+            this.ProgressBarDisabled.Name = "ProgressBarDisabled";
+            this.ProgressBarDisabled.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
+            this.ProgressBarDisabled.Size = new System.Drawing.Size(738, 23);
+            this.ProgressBarDisabled.StateCommon.Back.Color1 = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(0)))), ((int)(((byte)(0)))));
+            this.ProgressBarDisabled.StateCommon.Border.DrawBorders = ((Krypton.Toolkit.PaletteDrawBorders)((((Krypton.Toolkit.PaletteDrawBorders.Top | Krypton.Toolkit.PaletteDrawBorders.Bottom) 
             | Krypton.Toolkit.PaletteDrawBorders.Left) 
             | Krypton.Toolkit.PaletteDrawBorders.Right)));
-            this.kryptonProgressBar2.StateCommon.Border.Rounding = 10F;
-            this.kryptonProgressBar2.TabIndex = 12;
-            this.kryptonProgressBar2.Text = "Disabled";
-            this.kryptonProgressBar2.Value = 56;
-            this.kryptonProgressBar2.Values.Text = "Disabled";
+            this.ProgressBarDisabled.StateCommon.Border.Rounding = 10F;
+            this.ProgressBarDisabled.TabIndex = 12;
+            this.ProgressBarDisabled.Text = "Disabled (RTL)";
+            this.ProgressBarDisabled.TextBackdropColor = System.Drawing.Color.Empty;
+            this.ProgressBarDisabled.TextShadowColor = System.Drawing.Color.Empty;
+            this.ProgressBarDisabled.Value = 75;
+            this.ProgressBarDisabled.Values.Text = "Disabled (RTL)";
             // 
             // kryptonButton1
             // 
-            this.kryptonButton1.Location = new System.Drawing.Point(52, 314);
-            this.kryptonButton1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.kryptonButton1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.kryptonButton1.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.kryptonButton1.Location = new System.Drawing.Point(704, 357);
+            this.kryptonButton1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonButton1.Name = "kryptonButton1";
-            this.kryptonButton1.Size = new System.Drawing.Size(471, 25);
+            this.kryptonButton1.Size = new System.Drawing.Size(73, 29);
             this.kryptonButton1.StateCommon.Back.Color1 = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(192)))));
             this.kryptonButton1.StateCommon.Border.DrawBorders = ((Krypton.Toolkit.PaletteDrawBorders)((((Krypton.Toolkit.PaletteDrawBorders.Top | Krypton.Toolkit.PaletteDrawBorders.Bottom) 
             | Krypton.Toolkit.PaletteDrawBorders.Left) 
@@ -98,72 +247,99 @@ namespace KryptonScrollbarExamples
             this.kryptonButton1.StateCommon.Border.Rounding = 10F;
             this.kryptonButton1.TabIndex = 11;
             this.kryptonButton1.Values.DropDownArrowColor = System.Drawing.Color.Empty;
-            this.kryptonButton1.Values.Text = "kryptonButton1";
+            this.kryptonButton1.Values.Text = "&Close";
+            this.kryptonButton1.Click += new System.EventHandler(this.kryptonButton1_Click);
             // 
             // kryptonThemeComboBox1
             // 
+            this.kryptonThemeComboBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.kryptonThemeComboBox1.DefaultPalette = Krypton.Toolkit.PaletteMode.Office2007Blue;
             this.kryptonThemeComboBox1.DisplayMember = "Key";
             this.kryptonThemeComboBox1.DropDownWidth = 321;
             this.kryptonThemeComboBox1.IntegralHeight = false;
-            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(215, 4);
-            this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
+            this.kryptonThemeComboBox1.Location = new System.Drawing.Point(104, 10);
+            this.kryptonThemeComboBox1.Margin = new System.Windows.Forms.Padding(2);
             this.kryptonThemeComboBox1.Name = "kryptonThemeComboBox1";
-            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(321, 26);
+            this.kryptonThemeComboBox1.Size = new System.Drawing.Size(677, 24);
             this.kryptonThemeComboBox1.StateCommon.ComboBox.Content.TextH = Krypton.Toolkit.PaletteRelativeAlign.Near;
             this.kryptonThemeComboBox1.TabIndex = 10;
             this.kryptonThemeComboBox1.ValueMember = "Value";
             // 
-            // kryptonProgressBar1
-            // 
-            this.kryptonProgressBar1.Location = new System.Drawing.Point(13, 12);
-            this.kryptonProgressBar1.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
-            this.kryptonProgressBar1.Name = "kryptonProgressBar1";
-            this.kryptonProgressBar1.Orientation = Krypton.Toolkit.VisualOrientation.Left;
-            this.kryptonProgressBar1.Size = new System.Drawing.Size(32, 327);
-            this.kryptonProgressBar1.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
-            this.kryptonProgressBar1.TabIndex = 9;
-            this.kryptonProgressBar1.Values.Text = "";
-            // 
-            // progressBar1
-            // 
-            this.progressBar1.Location = new System.Drawing.Point(52, 196);
-            this.progressBar1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
-            this.progressBar1.Name = "progressBar1";
-            this.progressBar1.Size = new System.Drawing.Size(471, 28);
-            this.progressBar1.StateCommon.Back.Color1 = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(192)))), ((int)(((byte)(0)))));
-            this.progressBar1.StateCommon.Border.DrawBorders = ((Krypton.Toolkit.PaletteDrawBorders)((((Krypton.Toolkit.PaletteDrawBorders.Top | Krypton.Toolkit.PaletteDrawBorders.Bottom) 
-            | Krypton.Toolkit.PaletteDrawBorders.Left) 
-            | Krypton.Toolkit.PaletteDrawBorders.Right)));
-            this.progressBar1.StateCommon.Border.Rounding = 10F;
-            this.progressBar1.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
-            this.progressBar1.TabIndex = 8;
-            this.progressBar1.Value = 56;
-            this.progressBar1.Values.Text = "";
-            // 
             // pbVertical
             // 
-            this.pbVertical.Location = new System.Drawing.Point(52, 160);
-            this.pbVertical.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.pbVertical.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.pbVertical.Location = new System.Drawing.Point(10, 10);
+            this.pbVertical.Margin = new System.Windows.Forms.Padding(2);
             this.pbVertical.Name = "pbVertical";
-            this.pbVertical.Size = new System.Drawing.Size(471, 28);
-            this.pbVertical.StateCommon.Back.Color1 = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(224)))), ((int)(((byte)(192)))));
-            this.pbVertical.TabIndex = 7;
-            this.pbVertical.Value = 56;
-            this.pbVertical.Values.Text = "";
+            this.pbVertical.Orientation = Krypton.Toolkit.VisualOrientation.Left;
+            this.pbVertical.Size = new System.Drawing.Size(24, 376);
+            this.pbVertical.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
+            this.pbVertical.TabIndex = 9;
+            this.pbVertical.Text = "75%";
+            this.pbVertical.TextBackdropColor = System.Drawing.Color.Empty;
+            this.pbVertical.TextShadowColor = System.Drawing.Color.Empty;
+            this.pbVertical.UseValueAsText = true;
+            this.pbVertical.Value = 75;
+            this.pbVertical.Values.Text = "75%";
+            // 
+            // pbCustomColor
+            // 
+            this.pbCustomColor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pbCustomColor.Location = new System.Drawing.Point(43, 165);
+            this.pbCustomColor.Name = "pbCustomColor";
+            this.pbCustomColor.Size = new System.Drawing.Size(738, 23);
+            this.pbCustomColor.StateCommon.Back.Color1 = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(192)))), ((int)(((byte)(0)))));
+            this.pbCustomColor.StateCommon.Border.DrawBorders = ((Krypton.Toolkit.PaletteDrawBorders)((((Krypton.Toolkit.PaletteDrawBorders.Top | Krypton.Toolkit.PaletteDrawBorders.Bottom) 
+            | Krypton.Toolkit.PaletteDrawBorders.Left) 
+            | Krypton.Toolkit.PaletteDrawBorders.Right)));
+            this.pbCustomColor.StateCommon.Border.Rounding = 10F;
+            this.pbCustomColor.Style = System.Windows.Forms.ProgressBarStyle.Blocks;
+            this.pbCustomColor.TabIndex = 8;
+            this.pbCustomColor.Text = "75%";
+            this.pbCustomColor.TextBackdropColor = System.Drawing.Color.Empty;
+            this.pbCustomColor.TextShadowColor = System.Drawing.Color.Empty;
+            this.pbCustomColor.UseValueAsText = true;
+            this.pbCustomColor.Value = 75;
+            this.pbCustomColor.Values.ExtraText = " (Custom Color)";
+            this.pbCustomColor.Values.Text = "75%";
+            // 
+            // pbHorizontal2
+            // 
+            this.pbHorizontal2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pbHorizontal2.Location = new System.Drawing.Point(43, 130);
+            this.pbHorizontal2.Name = "pbHorizontal2";
+            this.pbHorizontal2.Size = new System.Drawing.Size(738, 23);
+            this.pbHorizontal2.StateCommon.Back.Color1 = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(224)))), ((int)(((byte)(192)))));
+            this.pbHorizontal2.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
+            this.pbHorizontal2.TabIndex = 7;
+            this.pbHorizontal2.Text = "75%";
+            this.pbHorizontal2.TextBackdropColor = System.Drawing.Color.Empty;
+            this.pbHorizontal2.TextShadowColor = System.Drawing.Color.Empty;
+            this.pbHorizontal2.UseValueAsText = true;
+            this.pbHorizontal2.Value = 75;
+            this.pbHorizontal2.Values.Text = "75%";
             // 
             // pbHorizontal
             // 
-            this.pbHorizontal.Location = new System.Drawing.Point(52, 97);
-            this.pbHorizontal.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.pbHorizontal.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.pbHorizontal.Location = new System.Drawing.Point(43, 79);
             this.pbHorizontal.Name = "pbHorizontal";
-            this.pbHorizontal.Size = new System.Drawing.Size(471, 55);
+            this.pbHorizontal.Size = new System.Drawing.Size(738, 45);
             this.pbHorizontal.StateCommon.Back.Color1 = System.Drawing.Color.FromArgb(((int)(((byte)(255)))), ((int)(((byte)(255)))), ((int)(((byte)(128)))));
             this.pbHorizontal.StateCommon.Back.Draw = Krypton.Toolkit.InheritBool.True;
             this.pbHorizontal.TabIndex = 4;
-            this.pbHorizontal.Text = "10";
+            this.pbHorizontal.Text = "75%";
+            this.pbHorizontal.TextBackdropColor = System.Drawing.Color.Empty;
+            this.pbHorizontal.TextShadowColor = System.Drawing.Color.Empty;
+            this.pbHorizontal.UseValueAsText = true;
+            this.pbHorizontal.Value = 75;
             this.pbHorizontal.Values.ExtraText = "of 100";
-            this.pbHorizontal.Values.Text = "10";
+            this.pbHorizontal.Values.Text = "75%";
             // 
             // knudHorizontal
             // 
@@ -172,8 +348,7 @@ namespace KryptonScrollbarExamples
             0,
             0,
             0});
-            this.knudHorizontal.Location = new System.Drawing.Point(215, 48);
-            this.knudHorizontal.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.knudHorizontal.Location = new System.Drawing.Point(104, 41);
             this.knudHorizontal.Maximum = new decimal(new int[] {
             100,
             0,
@@ -185,7 +360,7 @@ namespace KryptonScrollbarExamples
             0,
             0});
             this.knudHorizontal.Name = "knudHorizontal";
-            this.knudHorizontal.Size = new System.Drawing.Size(160, 26);
+            this.knudHorizontal.Size = new System.Drawing.Size(71, 24);
             this.knudHorizontal.TabIndex = 3;
             this.knudHorizontal.Value = new decimal(new int[] {
             0,
@@ -197,16 +372,18 @@ namespace KryptonScrollbarExamples
             // kryptonLabel1
             // 
             this.kryptonLabel1.LabelStyle = Krypton.Toolkit.LabelStyle.BoldPanel;
-            this.kryptonLabel1.Location = new System.Drawing.Point(52, 48);
-            this.kryptonLabel1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.kryptonLabel1.Location = new System.Drawing.Point(43, 43);
             this.kryptonLabel1.Name = "kryptonLabel1";
-            this.kryptonLabel1.Size = new System.Drawing.Size(56, 24);
+            this.kryptonLabel1.Size = new System.Drawing.Size(50, 21);
             this.kryptonLabel1.TabIndex = 2;
             this.kryptonLabel1.Values.Text = "Value:";
             // 
             // kryptonManager1
             // 
+            this.kryptonManager1.BaseFont = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.kryptonManager1.GlobalPaletteMode = Krypton.Toolkit.PaletteMode.Office2007Blue;
+            this.kryptonManager1.ToolkitStrings.MessageBoxStrings.LessDetails = "L&ess Details...";
+            this.kryptonManager1.ToolkitStrings.MessageBoxStrings.MoreDetails = "&More Details...";
             // 
             // statusStrip1
             // 
@@ -214,18 +391,16 @@ namespace KryptonScrollbarExamples
             this.statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.kryptonProgressBarToolStripItem1});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 345);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 398);
             this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 19, 0);
             this.statusStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.ManagerRenderMode;
-            this.statusStrip1.Size = new System.Drawing.Size(553, 29);
+            this.statusStrip1.Size = new System.Drawing.Size(799, 24);
             this.statusStrip1.TabIndex = 1;
             this.statusStrip1.Text = "statusStrip1";
             // 
             // kryptonProgressBarToolStripItem1
             // 
             this.kryptonProgressBarToolStripItem1.Name = "kryptonProgressBarToolStripItem1";
-            this.kryptonProgressBarToolStripItem1.Size = new System.Drawing.Size(133, 27);
             this.kryptonProgressBarToolStripItem1.StateCommon.Back.Color1 = System.Drawing.Color.Green;
             this.kryptonProgressBarToolStripItem1.StateDisabled.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
             this.kryptonProgressBarToolStripItem1.StateNormal.Back.ColorStyle = Krypton.Toolkit.PaletteColorStyle.OneNote;
@@ -235,20 +410,22 @@ namespace KryptonScrollbarExamples
             // 
             // Form1
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(553, 374);
+            this.ClientSize = new System.Drawing.Size(799, 422);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.kryptonPanel1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
-            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.MaximizeBox = false;
             this.Name = "Form1";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Krypton ProgressBar Examples";
+            this.Load += new System.EventHandler(this.Form1_Load);
             ((System.ComponentModel.ISupportInitialize)(this.kryptonPanel1)).EndInit();
             this.kryptonPanel1.ResumeLayout(false);
             this.kryptonPanel1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbProgressBarStyle)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.kcmbColorStyle)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.kryptonThemeComboBox1)).EndInit();
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
@@ -260,18 +437,29 @@ namespace KryptonScrollbarExamples
         #endregion
 
         private Krypton.Toolkit.KryptonPanel kryptonPanel1;
-        private Krypton.Toolkit.KryptonProgressBar pbVertical;
+        private Krypton.Toolkit.KryptonProgressBar pbHorizontal2;
         private Krypton.Toolkit.KryptonProgressBar pbHorizontal;
         private Krypton.Toolkit.KryptonNumericUpDown knudHorizontal;
         private Krypton.Toolkit.KryptonLabel kryptonLabel1;
-        private Krypton.Toolkit.KryptonProgressBar progressBar1;
-        private Krypton.Toolkit.KryptonProgressBar kryptonProgressBar1;
+        private Krypton.Toolkit.KryptonProgressBar pbCustomColor;
+        private Krypton.Toolkit.KryptonProgressBar pbVertical;
         private Krypton.Toolkit.KryptonThemeComboBox kryptonThemeComboBox1;
         private Krypton.Toolkit.KryptonManager kryptonManager1;
         private Krypton.Toolkit.KryptonButton kryptonButton1;
-        private Krypton.Toolkit.KryptonProgressBar kryptonProgressBar2;
+        private Krypton.Toolkit.KryptonProgressBar ProgressBarDisabled;
         private System.Windows.Forms.StatusStrip statusStrip1;
         private Krypton.Toolkit.KryptonProgressBarToolStripItem kryptonProgressBarToolStripItem1;
+        private Krypton.Toolkit.KryptonLabel kryptonLabel2;
+        private Krypton.Toolkit.KryptonTrackBar ktrkProgressValues;
+        private Krypton.Toolkit.KryptonCheckBox kchkShowTextShadow;
+        private Krypton.Toolkit.KryptonLabel kryptonLabel3;
+        private Krypton.Toolkit.KryptonColorButton kcbtnProgressBarColour;
+        private Krypton.Toolkit.KryptonComboBox kcmbProgressBarStyle;
+        private Krypton.Toolkit.KryptonLabel klblColorStyle;
+        private Krypton.Toolkit.KryptonComboBox kcmbColorStyle;
+        private Krypton.Toolkit.KryptonCheckBox kchkShowTextBackdrop;
+        private Krypton.Toolkit.KryptonColorButton kcbtnBackdropColor;
+        private Krypton.Toolkit.KryptonCheckBox kchkUseProgressValueAsText;
     }
 }
 

--- a/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/Form1.cs
@@ -1,26 +1,129 @@
 ﻿// *****************************************************************************
 // BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit)
-//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2023 - 2024. All rights reserved.
+// By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege 2023 - 2025. All rights reserved.
 // *****************************************************************************
 
 using System;
-
+using System.Windows.Forms;
 using Krypton.Toolkit;
 
-namespace KryptonScrollbarExamples
+namespace KryptonProgressBarExamples
 {
     public partial class Form1 : KryptonForm
     {
         public Form1() => InitializeComponent();
 
+        private void kryptonButton1_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+
+        private void Form1_Load(object sender, EventArgs e)
+        {
+            foreach (object? value in Enum.GetValues(typeof(ProgressBarStyle)))
+            {
+                kcmbProgressBarStyle.Items.Add(value);
+            }
+
+            kcmbProgressBarStyle.SelectedIndex = 1;
+
+            foreach (object? value in Enum.GetValues(typeof(PaletteColorStyle)))
+            {
+                kcmbColorStyle.Items.Add(value);
+            }
+
+            kcmbColorStyle.SelectedItem = PaletteColorStyle.GlassNormalFull;
+
+            ktrkProgressValues.Value = 75;
+        }
+
         private void knudHorizontal_ValueChanged(object sender, EventArgs e)
         {
-            pbHorizontal.Value = (int)knudHorizontal.Value;
-            pbHorizontal.Text = pbHorizontal.Value.ToString();
-            pbVertical.Value = (int)knudHorizontal.Value;
-            kryptonProgressBar1.Value = (int)knudHorizontal.Value;
-            kryptonProgressBar2.Value = (int)knudHorizontal.Value;
-            kryptonProgressBarToolStripItem1.Value = (int)knudHorizontal.Value;
+            ktrkProgressValues.Value = (int)knudHorizontal.Value;
+            pbHorizontal.Value = ktrkProgressValues.Value;
+            pbHorizontal2.Value = ktrkProgressValues.Value;
+            pbCustomColor.Value = ktrkProgressValues.Value;
+            pbVertical.Value = ktrkProgressValues.Value;
+            ProgressBarDisabled.Value = ktrkProgressValues.Value;
+            kryptonProgressBarToolStripItem1.Value = ktrkProgressValues.Value;
+        }
+
+        private void kchkUseProgressValueAsText_CheckedChanged(object sender, EventArgs e)
+        {
+            pbHorizontal.UseValueAsText = kchkUseProgressValueAsText.Checked;
+            pbHorizontal2.UseValueAsText = kchkUseProgressValueAsText.Checked;
+            pbCustomColor.UseValueAsText = kchkUseProgressValueAsText.Checked;
+            pbVertical.UseValueAsText = kchkUseProgressValueAsText.Checked;
+            ProgressBarDisabled.UseValueAsText = kchkUseProgressValueAsText.Checked;
+            kryptonProgressBarToolStripItem1.UseValueAsText = kchkUseProgressValueAsText.Checked;
+        }
+
+        private void kcbtnBackdropColor_SelectedColorChanged(object sender, ColorEventArgs e)
+        {
+            pbHorizontal.TextBackdropColor = e.Color;
+            pbHorizontal2.TextBackdropColor = e.Color;
+            pbCustomColor.TextBackdropColor = e.Color;
+            pbVertical.TextBackdropColor = e.Color;
+            ProgressBarDisabled.TextBackdropColor = e.Color;
+            kryptonProgressBarToolStripItem1.KryptonProgressBarHost.TextBackdropColor = e.Color;
+        }
+
+        private void kchkShowTextBackdrop_CheckedChanged(object sender, EventArgs e)
+        {
+            pbHorizontal.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+            pbHorizontal2.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+            pbCustomColor.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+            pbVertical.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+            ProgressBarDisabled.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+            kryptonProgressBarToolStripItem1.KryptonProgressBarHost.ShowTextBackdrop = kchkShowTextBackdrop.Checked;
+        }
+
+        private void kcmbProgressBarStyle_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var newStyle = (ProgressBarStyle)Enum.Parse(typeof(ProgressBarStyle), kcmbProgressBarStyle.Text);
+            pbHorizontal.Style = newStyle;
+            pbHorizontal2.Style = newStyle;
+            pbCustomColor.Style = newStyle;
+            pbVertical.Style = newStyle;
+            ProgressBarDisabled.Style = newStyle;
+            kryptonProgressBarToolStripItem1.Style = newStyle;
+        }
+
+        private void kcmbColorStyle_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var newStyle = (PaletteColorStyle)Enum.Parse(typeof(PaletteColorStyle), kcmbColorStyle.Text);
+            pbHorizontal.ValueBackColorStyle = newStyle;
+            pbHorizontal2.ValueBackColorStyle = newStyle;
+            pbCustomColor.ValueBackColorStyle = newStyle;
+            pbVertical.ValueBackColorStyle = newStyle;
+            ProgressBarDisabled.ValueBackColorStyle = newStyle;
+            kryptonProgressBarToolStripItem1.KryptonProgressBarHost.ValueBackColorStyle = newStyle;
+        }
+
+        private void kchkShowTextShadow_CheckedChanged(object sender, EventArgs e)
+        {
+            pbHorizontal.ShowTextShadow = kchkShowTextShadow.Checked;
+            pbHorizontal2.ShowTextShadow = kchkShowTextShadow.Checked;
+            pbCustomColor.ShowTextShadow = kchkShowTextShadow.Checked;
+            pbVertical.ShowTextShadow = kchkShowTextShadow.Checked;
+            ProgressBarDisabled.ShowTextShadow = kchkShowTextShadow.Checked;
+            kryptonProgressBarToolStripItem1.KryptonProgressBarHost.ShowTextShadow = kchkShowTextShadow.Checked;
+        }
+
+        private void ktrkProgressValues_ValueChanged(object sender, EventArgs e)
+        {
+            pbHorizontal.Value = ktrkProgressValues.Value;
+            pbHorizontal2.Value = ktrkProgressValues.Value;
+            pbCustomColor.Value = ktrkProgressValues.Value;
+            knudHorizontal.Value = ktrkProgressValues.Value;
+            pbVertical.Value = ktrkProgressValues.Value;
+            ProgressBarDisabled.Value = ktrkProgressValues.Value;
+            kryptonProgressBarToolStripItem1.Value = ktrkProgressValues.Value;
+        }
+
+        private void kcbtnProgressBarColour_SelectedColorChanged(object sender, ColorEventArgs e)
+        {
+            pbCustomColor.StateCommon.Back.Color1 = e.Color;
         }
     }
 }

--- a/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/Form1.resx
+++ b/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/Form1.resx
@@ -117,10 +117,25 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="kcbtnProgressBarColour.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
+  <data name="kcbtnBackdropColor.Values.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAL
+        DAAACwwBP0AiyAAAAAd0SU1FB9gBEgI0L+a2mIYAAAATSURBVDhPYxgFo2AUjAIwYGAAAAQQAAGnRHxj
+        AAAAAElFTkSuQmCC
+</value>
+  </data>
   <metadata name="kryptonManager1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>165, 17</value>
+    <value>201, 20</value>
   </metadata>
 </root>

--- a/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/KryptonProgressbar Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/KryptonProgressbar Examples 2022.csproj
@@ -21,6 +21,19 @@
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
+    <ItemGroup>
+      <Compile Update="Properties\Resources.Designer.cs">
+        <DesignTime>True</DesignTime>
+        <AutoGen>True</AutoGen>
+        <DependentUpon>Resources.resx</DependentUpon>
+      </Compile>
+    </ItemGroup>
+    <ItemGroup>
+      <EmbeddedResource Update="Properties\Resources.resx">
+        <Generator>ResXFileCodeGenerator</Generator>
+        <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      </EmbeddedResource>
+    </ItemGroup>
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>

--- a/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/Program.cs
+++ b/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/Program.cs
@@ -1,12 +1,12 @@
 // *****************************************************************************
 // BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit)
-//  By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV) 2023 - 2024. All rights reserved.
+// By Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege 2023 - 2025. All rights reserved.
 // *****************************************************************************
 
 using System;
 using System.Windows.Forms;
 
-namespace KryptonScrollbarExamples
+namespace KryptonProgressBarExamples
 {
     internal static class Program
     {


### PR DESCRIPTION
Implements #249 

- Updated demo to include newest V100 options including color customization and progress value display options.

- FIX: KryptonAboutToolkit to use updated `ToolkitSupportType`.

---

<img width="1020" height="579" alt="{16BA2D13-6FDF-4BA2-8683-EC60C6E7CC61}" src="https://github.com/user-attachments/assets/59e675e9-40c5-461b-99fc-9974040076fd" />

---

<img width="1169" height="270" alt="{035A5CAD-2325-4201-A1F2-BAF711ECA5AC}" src="https://github.com/user-attachments/assets/9240efd5-66df-4814-b6a1-5bff5bc02e29" />
