### PR TITLE
254 V95 Switch V95 branch to actually use V95 NuGet packages; add build script

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,8 @@
 <Project>
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and $([System.String]::Copy('$(TargetFrameworkVersion)').StartsWith('v4.'))">
+    <ApplicationManifest>$(MSBuildThisFileDirectory)app.net4x.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' or ! ('$(TargetFrameworkIdentifier)' == '.NETFramework' and $([System.String]::Copy('$(TargetFrameworkVersion)').StartsWith('v4.'))) ">
     <ApplicationManifest>$(MSBuildThisFileDirectory)app.core.manifest</ApplicationManifest>
   </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <ApplicationManifest>$(MSBuildThisFileDirectory)app.core.manifest</ApplicationManifest>
+  </PropertyGroup>
+</Project>

--- a/Documents/Help/Changelog.md
+++ b/Documents/Help/Changelog.md
@@ -2,6 +2,7 @@
 
 
 ## 2025-11-xx - Build 2511 - November
+* Resolved [#254](https://github.com/Krypton-Suite/Standard-Toolkit-Demos/issues/254) Change csproj files to use V95 NuGet packages
 * Resolved [#244](https://github.com/Krypton-Suite/Standard-Toolkit-Demos/issues/244) KryptonVerticalScrollBar demo scrollbar dimensions incorrect.
 * Resolved [#231](https://github.com/Krypton-Suite/Standard-Toolkit-Demos/issues/231), `Explorer` launch of "Workspace Persistence" causes an exception to be displayed
 * Resolved [#2301](https://github.com/Krypton-Suite/Standard-Toolkit-Demos/issues/230), `Explorer` launch of Workspace example does nothing

--- a/Source/Krypton Docking Examples/Docking Customized/Docking Customized 2022.csproj
+++ b/Source/Krypton Docking Examples/Docking Customized/Docking Customized 2022.csproj
@@ -10,23 +10,21 @@
         <UseWindowsForms>true</UseWindowsForms>
         <PlatformTarget>AnyCPU</PlatformTarget>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
-    <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
-    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
+        <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+        <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
 
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
-    <ItemGroup>
-      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
-    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
+            <ItemGroup>
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+            </ItemGroup>
+        </When>
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />

--- a/Source/Krypton Docking Examples/Docking Customized/Docking Customized 2022.csproj
+++ b/Source/Krypton Docking Examples/Docking Customized/Docking Customized 2022.csproj
@@ -12,19 +12,21 @@
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
     <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
+    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
 
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
+    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
-            <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Docking.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
-            </ItemGroup>
-        </When>
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />

--- a/Source/Krypton Docking Examples/Docking Customized/app.manifest
+++ b/Source/Krypton Docking Examples/Docking Customized/app.manifest
@@ -54,7 +54,6 @@
   
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>

--- a/Source/Krypton Docking Examples/Docking Flags/Docking Flags 2022.csproj
+++ b/Source/Krypton Docking Examples/Docking Flags/Docking Flags 2022.csproj
@@ -12,18 +12,21 @@
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
     <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
+    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
 
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
+    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
-            <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Docking.Canary" Version="90.23.12.352-beta" />
-            </ItemGroup>
-        </When>
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />

--- a/Source/Krypton Docking Examples/Docking Flags/Docking Flags 2022.csproj
+++ b/Source/Krypton Docking Examples/Docking Flags/Docking Flags 2022.csproj
@@ -10,28 +10,24 @@
         <UseWindowsForms>true</UseWindowsForms>
         <PlatformTarget>AnyCPU</PlatformTarget>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
-    <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
-    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
-
+        <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+        <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
-    <ItemGroup>
-      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
-    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
+            <ItemGroup>
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+            </ItemGroup>
+        </When>
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Docking\Krypton.Docking 2022.csproj" />
-            </ItemGroup>                   
+            </ItemGroup>
         </Otherwise>
     </Choose>
     <PropertyGroup>

--- a/Source/Krypton Docking Examples/Docking Flags/app.manifest
+++ b/Source/Krypton Docking Examples/Docking Flags/app.manifest
@@ -54,7 +54,6 @@
   
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>

--- a/Source/Krypton Docking Examples/Docking Persistence/Docking Persistence 2022.csproj
+++ b/Source/Krypton Docking Examples/Docking Persistence/Docking Persistence 2022.csproj
@@ -12,19 +12,21 @@
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
     <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
+    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
 
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
+    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
-            <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Docking.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
-            </ItemGroup>
-        </When>
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
@@ -35,6 +37,11 @@
     </Choose>
     <PropertyGroup>
         <OutputPath>..\..\..\Binaries\Krypton Demos\$(Configuration)\</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
         <ApplicationManifest>app.manifest</ApplicationManifest>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+        <ApplicationManifest>app.core.manifest</ApplicationManifest>
     </PropertyGroup>
 </Project>

--- a/Source/Krypton Docking Examples/Docking Persistence/Docking Persistence 2022.csproj
+++ b/Source/Krypton Docking Examples/Docking Persistence/Docking Persistence 2022.csproj
@@ -10,23 +10,20 @@
         <UseWindowsForms>true</UseWindowsForms>
         <PlatformTarget>AnyCPU</PlatformTarget>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
-    <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
-    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
-
+        <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+        <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
-    <ItemGroup>
-      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
-    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
+            <ItemGroup>
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+            </ItemGroup>
+        </When>
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />

--- a/Source/Krypton Docking Examples/Docking Persistence/app.core.manifest
+++ b/Source/Krypton Docking Examples/Docking Persistence/app.core.manifest
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/Source/Krypton Docking Examples/External Drag To Docking/ContentTreeView.cs
+++ b/Source/Krypton Docking Examples/External Drag To Docking/ContentTreeView.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  * 
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2017 - 2025. All rights reserved. 
  *  
  */
 #endregion
@@ -13,6 +13,7 @@
 using System;
 using System.Drawing;
 using System.Windows.Forms;
+using System.ComponentModel;
 
 using Krypton.Docking;
 using Krypton.Navigator;
@@ -30,11 +31,17 @@ namespace ExternalDragToDocking
 
     public class DraggableTreeView : TreeView
     {
+        private Form1 _form1;
         private bool _dragging;
         private TreeNode _dragNode;
         private Rectangle _dragRect;
 
-        public Form1 Form1 { get; set; }
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public Form1 Form1
+        {
+            get => _form1;
+            set => _form1 = value;
+        }
 
         protected override void OnMouseDown(MouseEventArgs e)
         {

--- a/Source/Krypton Docking Examples/External Drag To Docking/External Drag To Docking 2022.csproj
+++ b/Source/Krypton Docking Examples/External Drag To Docking/External Drag To Docking 2022.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
     <PropertyGroup>
         <TargetFrameworks>net48;net8.0-windows;net9.0-windows</TargetFrameworks>
         <OutputType>WinExe</OutputType>
@@ -10,20 +10,20 @@
         <UseWindowsForms>true</UseWindowsForms>
         <PlatformTarget>AnyCPU</PlatformTarget>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
-    <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
-
+        <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
+    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
-            <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Docking.Canary" Version="90.23.12.352-beta" />
-            </ItemGroup>
-        </When>
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />

--- a/Source/Krypton Docking Examples/External Drag To Docking/External Drag To Docking 2022.csproj
+++ b/Source/Krypton Docking Examples/External Drag To Docking/External Drag To Docking 2022.csproj
@@ -10,20 +10,17 @@
         <UseWindowsForms>true</UseWindowsForms>
         <PlatformTarget>AnyCPU</PlatformTarget>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-        <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
-    <ItemGroup>
-      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
-    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
+            <ItemGroup>
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+            </ItemGroup>
+        </When>
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />

--- a/Source/Krypton Docking Examples/External Drag To Docking/app.manifest
+++ b/Source/Krypton Docking Examples/External Drag To Docking/app.manifest
@@ -49,16 +49,12 @@
        DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
        to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
-       
        Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
-  
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
-      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
       <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
     </windowsSettings>
   </application>
-  
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
   <!--

--- a/Source/Krypton Docking Examples/Multi Control Docking/Multi Control Docking 2022.csproj
+++ b/Source/Krypton Docking Examples/Multi Control Docking/Multi Control Docking 2022.csproj
@@ -10,23 +10,19 @@
         <UseWindowsForms>true</UseWindowsForms>
         <PlatformTarget>AnyCPU</PlatformTarget>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
-    <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
-    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
-
+        <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+        <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
-    <ItemGroup>
-      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
-    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
+            <ItemGroup>
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+            </ItemGroup>
+        </When>
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />

--- a/Source/Krypton Docking Examples/Multi Control Docking/Multi Control Docking 2022.csproj
+++ b/Source/Krypton Docking Examples/Multi Control Docking/Multi Control Docking 2022.csproj
@@ -12,18 +12,21 @@
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
     <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
+    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
 
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
+    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
-            <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Docking.Canary" Version="90.23.12.352-beta" />
-            </ItemGroup>
-        </When>
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
@@ -33,6 +36,11 @@
     </Choose>
     <PropertyGroup>
         <OutputPath>..\..\..\Binaries\Krypton Demos\$(Configuration)\</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
         <ApplicationManifest>app.manifest</ApplicationManifest>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+        <ApplicationManifest>app.core.manifest</ApplicationManifest>
     </PropertyGroup>
 </Project>

--- a/Source/Krypton Docking Examples/Multi Control Docking/app.core.manifest
+++ b/Source/Krypton Docking Examples/Multi Control Docking/app.core.manifest
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/Source/Krypton Docking Examples/Navigator + FloatingWindows/Navigator + FloatingWindows 2022.csproj
+++ b/Source/Krypton Docking Examples/Navigator + FloatingWindows/Navigator + FloatingWindows 2022.csproj
@@ -10,23 +10,19 @@
         <UseWindowsForms>true</UseWindowsForms>
         <PlatformTarget>AnyCPU</PlatformTarget>
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-    <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
-    <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
-    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
-
+        <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
+        <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
-    <ItemGroup>
-      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
-      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
-    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
+            <ItemGroup>
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+            </ItemGroup>
+        </When>
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />

--- a/Source/Krypton Docking Examples/Navigator + FloatingWindows/Navigator + FloatingWindows 2022.csproj
+++ b/Source/Krypton Docking Examples/Navigator + FloatingWindows/Navigator + FloatingWindows 2022.csproj
@@ -12,18 +12,21 @@
         <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
     <ApplicationHighDpiMode>SystemAware</ApplicationHighDpiMode>
     <ForceDesignerDpiUnaware>true</ForceDesignerDpiUnaware>
+    <GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
 
     </PropertyGroup>
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
+    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
-            <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Docking.Canary" Version="90.23.12.352-beta" />
-            </ItemGroup>
-        </When>
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />
@@ -33,6 +36,11 @@
     </Choose>
     <PropertyGroup>
         <OutputPath>..\..\..\Binaries\Krypton Demos\$(Configuration)\</OutputPath>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
         <ApplicationManifest>app.manifest</ApplicationManifest>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+        <ApplicationManifest>app.core.manifest</ApplicationManifest>
     </PropertyGroup>
 </Project>

--- a/Source/Krypton Docking Examples/Navigator + FloatingWindows/app.core.manifest
+++ b/Source/Krypton Docking Examples/Navigator + FloatingWindows/app.core.manifest
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/Source/Krypton Docking Examples/Standard Docking/Standard Docking 2022.csproj
+++ b/Source/Krypton Docking Examples/Standard Docking/Standard Docking 2022.csproj
@@ -17,14 +17,15 @@
     <ItemGroup>
         <Content Include="Krypton.ico" />
     </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+      <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
+    </ItemGroup>
     <Choose>
-        <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
-            <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Docking.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
-            </ItemGroup>
-        </When>
+        <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
         <Otherwise>
             <ItemGroup>
                 <ProjectReference Include="..\..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />

--- a/Source/Krypton Explorer/Krypton Explorer 2022.csproj
+++ b/Source/Krypton Explorer/Krypton Explorer 2022.csproj
@@ -18,6 +18,10 @@
     <Content Include="Krypton.ico" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+    <PackageReference Include="Krypton.Toolkit" Version="95.25.8.235" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -42,12 +46,7 @@
     </None>
   </ItemGroup>
   <Choose>
-    <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
-      <ItemGroup>
-        <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-        <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
-      </ItemGroup>
-    </When>
+    <When Condition="'$(SolutionName.Endswith(`Nuget`))'" />
     <Otherwise>
       <ItemGroup>
         <ProjectReference Include="..\..\..\Standard-Toolkit\Source\Krypton Components\Krypton.Toolkit\Krypton.Toolkit 2022.csproj" />

--- a/Source/Krypton Navigator Examples/Basic Events/Basic Events 2022.csproj
+++ b/Source/Krypton Navigator Examples/Basic Events/Basic Events 2022.csproj
@@ -33,8 +33,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Expanding Pages/Expanding Pages 2022.csproj
+++ b/Source/Krypton Navigator Examples/Expanding Pages/Expanding Pages 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Navigator Context Menus/Form1.Designer.cs
+++ b/Source/Krypton Navigator Examples/Navigator Context Menus/Form1.Designer.cs
@@ -166,7 +166,6 @@ namespace NavigatorContextMenus
             this.kcmDollar1,
             this.kcmDollar2,
             this.kcmDollar3});
-            this.kcmItemsDollar.Text = "";
             // 
             // kcmDollar1
             // 
@@ -226,7 +225,6 @@ namespace NavigatorContextMenus
             this.kcmEuro3,
             this.kcmEuro4,
             this.kcmEuro5});
-            this.kcmItemsEuro.Text = "";
             // 
             // kcmEuro1
             // 
@@ -240,7 +238,6 @@ namespace NavigatorContextMenus
             // 
             // kcmSeparatorEuro
             // 
-            this.kcmSeparatorEuro.Text = "";
             // 
             // kcmEuro3
             // 
@@ -299,7 +296,6 @@ namespace NavigatorContextMenus
             this.kcmItemsYen.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.kcmYen1,
             this.kcmYen2});
-            this.kcmItemsYen.Text = "";
             // 
             // kcmYen1
             // 
@@ -313,7 +309,6 @@ namespace NavigatorContextMenus
             // 
             // kcmSeparatorYen
             // 
-            this.kcmSeparatorYen.Text = "";
             // 
             // kcmHeadingYenMore
             // 
@@ -325,7 +320,6 @@ namespace NavigatorContextMenus
             this.kcmItemsYenMore.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.kcmYen3,
             this.kcmYen4});
-            this.kcmItemsYenMore.Text = "";
             // 
             // kcmYen3
             // 
@@ -381,7 +375,6 @@ namespace NavigatorContextMenus
             this.kcmPound4,
             this.kcmPound5,
             this.kcmPound6});
-            this.kcmItemsPound.Text = "";
             // 
             // kcmPound1
             // 
@@ -401,7 +394,6 @@ namespace NavigatorContextMenus
             // kcmSeparatorPound
             // 
             this.kcmSeparatorPound.Horizontal = false;
-            this.kcmSeparatorPound.Text = "";
             // 
             // kcmPound4
             // 
@@ -436,7 +428,6 @@ namespace NavigatorContextMenus
             this.kcmPrevious,
             this.kcmNext,
             this.kcmLast});
-            this.kcmItemsNavigator.Text = "";
             // 
             // kcmFirst
             // 

--- a/Source/Krypton Navigator Examples/Navigator Context Menus/Navigator Context Menus 2022.csproj
+++ b/Source/Krypton Navigator Examples/Navigator Context Menus/Navigator Context Menus 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Navigator Modes/Navigator Modes 2022.csproj
+++ b/Source/Krypton Navigator Examples/Navigator Modes/Navigator Modes 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Navigator Palettes/Navigator Palettes 2022.csproj
+++ b/Source/Krypton Navigator Examples/Navigator Palettes/Navigator Palettes 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Navigator Playground/Navigator Playground 2022.csproj
+++ b/Source/Krypton Navigator Examples/Navigator Playground/Navigator Playground 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Navigator ToolTips/Navigator ToolTips 2022.csproj
+++ b/Source/Krypton Navigator Examples/Navigator ToolTips/Navigator ToolTips 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/OneNote Tabs/OneNote Tabs 2022.csproj
+++ b/Source/Krypton Navigator Examples/OneNote Tabs/OneNote Tabs 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Orientation + Alignment/Orientation + Alignment 2022.csproj
+++ b/Source/Krypton Navigator Examples/Orientation + Alignment/Orientation + Alignment 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Outlook Mockup/Outlook Mockup 2022.csproj
+++ b/Source/Krypton Navigator Examples/Outlook Mockup/Outlook Mockup 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Per-Tab Buttons/Per-Tab Buttons 2022.csproj
+++ b/Source/Krypton Navigator Examples/Per-Tab Buttons/Per-Tab Buttons 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Popup Pages/Popup Pages 2022.csproj
+++ b/Source/Krypton Navigator Examples/Popup Pages/Popup Pages 2022.csproj
@@ -21,8 +21,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Singleline + Multiline/Singleline + Multiline 2022.csproj
+++ b/Source/Krypton Navigator Examples/Singleline + Multiline/Singleline + Multiline 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/Tab Border Styles/Tab Border Styles 2022.csproj
+++ b/Source/Krypton Navigator Examples/Tab Border Styles/Tab Border Styles 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Navigator Examples/User Page Creation/User Page Creation 2022.csproj
+++ b/Source/Krypton Navigator Examples/User Page Creation/User Page Creation 2022.csproj
@@ -20,8 +20,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/Application Menu/Application Menu 2022.csproj
+++ b/Source/Krypton Ribbon Examples/Application Menu/Application Menu 2022.csproj
@@ -25,8 +25,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/Application Menu/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Application Menu/Form1.Designer.cs
@@ -133,10 +133,6 @@ namespace ApplicationMenu
             this.kryptonContextMenuItem4.Image = ((System.Drawing.Image)(resources.GetObject("kryptonContextMenuItem4.Image")));
             this.kryptonContextMenuItem4.Text = "Save &As";
             // 
-            // kryptonContextMenuSeparator1
-            // 
-            this.kryptonContextMenuSeparator1.Text = "";
-            // 
             // kryptonContextMenuItem5
             // 
             this.kryptonContextMenuItem5.Image = ((System.Drawing.Image)(resources.GetObject("kryptonContextMenuItem5.Image")));

--- a/Source/Krypton Ribbon Examples/Auto Shrinking Groups/Auto Shrinking Groups 2022.csproj
+++ b/Source/Krypton Ribbon Examples/Auto Shrinking Groups/Auto Shrinking Groups 2022.csproj
@@ -25,8 +25,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/Contextual Tabs/Contextual Tabs 2022.csproj
+++ b/Source/Krypton Ribbon Examples/Contextual Tabs/Contextual Tabs 2022.csproj
@@ -25,8 +25,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/KeyTips + Keyboard Access/KeyTips + Keyboard Access 2022.csproj
+++ b/Source/Krypton Ribbon Examples/KeyTips + Keyboard Access/KeyTips + Keyboard Access 2022.csproj
@@ -25,8 +25,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/KryptonGallery Examples/KryptonGallery Examples 2022.csproj
+++ b/Source/Krypton Ribbon Examples/KryptonGallery Examples/KryptonGallery Examples 2022.csproj
@@ -25,8 +25,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/MDI Ribbon/MDI Ribbon 2022.csproj
+++ b/Source/Krypton Ribbon Examples/MDI Ribbon/MDI Ribbon 2022.csproj
@@ -25,8 +25,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/Outlook Mail Clone/Form1.Designer.cs
+++ b/Source/Krypton Ribbon Examples/Outlook Mail Clone/Form1.Designer.cs
@@ -573,7 +573,6 @@ namespace OutlookMailClone
             this.cmsPasteItems.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.pasteToolStripMenuItem,
             this.pasteSpecialToolStripMenuItem});
-            this.cmsPasteItems.Text = "";
             // 
             // pasteToolStripMenuItem
             // 
@@ -600,10 +599,6 @@ namespace OutlookMailClone
             this.deleteToolStripMenuItem.Image = global::OutlookMailClone.Properties.Resources.QATDeleteSmall;
             this.deleteToolStripMenuItem.Text = "Delete";
             // 
-            // toolStripMenuItem5
-            // 
-            this.toolStripMenuItem5.Text = "";
-            // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Text = "Exit";
@@ -618,7 +613,6 @@ namespace OutlookMailClone
             // 
             this.cmsBusinessCardsItems.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.otherBusinessCardsToolStripMenuItem});
-            this.cmsBusinessCardsItems.Text = "";
             // 
             // otherBusinessCardsToolStripMenuItem
             // 
@@ -633,7 +627,6 @@ namespace OutlookMailClone
             // 
             this.cmsSignaturesItems.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.signaturesToolStripMenuItem});
-            this.cmsSignaturesItems.Text = "";
             // 
             // signaturesToolStripMenuItem
             // 
@@ -658,7 +651,6 @@ namespace OutlookMailClone
             this.clearFlagToolStripMenuItem1,
             this.kryptonContextMenuSeparator1,
             this.flagForRecipientsToolStripMenuItem1});
-            this.cmsFollowUpItems.Text = "";
             // 
             // todayToolStripMenuItem1
             // 
@@ -690,10 +682,6 @@ namespace OutlookMailClone
             this.customToolStripMenuItem1.Image = global::OutlookMailClone.Properties.Resources.OptionsToday;
             this.customToolStripMenuItem1.Text = "Custom...";
             // 
-            // kryptonContextMenuSeparator2
-            // 
-            this.kryptonContextMenuSeparator2.Text = "";
-            // 
             // addReminderToolStripMenuItem1
             // 
             this.addReminderToolStripMenuItem1.Image = global::OutlookMailClone.Properties.Resources.OptionsReminder;
@@ -703,21 +691,9 @@ namespace OutlookMailClone
             // 
             this.clearFlagToolStripMenuItem1.Text = "Clear Flag";
             // 
-            // kryptonContextMenuSeparator1
-            // 
-            this.kryptonContextMenuSeparator1.Text = "";
-            // 
             // flagForRecipientsToolStripMenuItem1
             // 
             this.flagForRecipientsToolStripMenuItem1.Text = "Flag For Recipients...";
-            // 
-            // toolStripMenuItem3
-            // 
-            this.toolStripMenuItem3.Text = "";
-            // 
-            // toolStripMenuItem4
-            // 
-            this.toolStripMenuItem4.Text = "";
             // 
             // cmsSpelling
             // 
@@ -736,7 +712,6 @@ namespace OutlookMailClone
             this.wordCountToolStripMenuItem,
             this.clearFlagToolStripMenuItem,
             this.flagForRecipientsToolStripMenuItem});
-            this.cmsSpellingItems.Text = "";
             // 
             // spellingGrammerToolStripMenuItem
             // 
@@ -781,14 +756,6 @@ namespace OutlookMailClone
             // 
             this.flagForRecipientsToolStripMenuItem.Text = "Flag for Recipients...";
             // 
-            // toolStripMenuItem1
-            // 
-            this.toolStripMenuItem1.Text = "";
-            // 
-            // toolStripMenuItem2
-            // 
-            this.toolStripMenuItem2.Text = "";
-            // 
             // cmsFormPublish
             // 
             this.cmsFormPublish.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
@@ -799,7 +766,6 @@ namespace OutlookMailClone
             this.cmsFormPublishItems.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.publishFormToolStripMenuItem,
             this.publishFormAsToolStripMenuItem});
-            this.cmsFormPublishItems.Text = "";
             // 
             // publishFormToolStripMenuItem
             // 
@@ -823,7 +789,6 @@ namespace OutlookMailClone
             this.convertTextToTableToolStripMenuItem,
             this.excelSpreadsheetToolStripMenuItem,
             this.quickTablesToolStripMenuItem});
-            this.cmsTableItems.Text = "";
             // 
             // insertTableToolStripMenuItem
             // 
@@ -859,7 +824,6 @@ namespace OutlookMailClone
             this.cmsTextBoxItems.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.drawTextBoxToolStripMenuItem,
             this.saveSelectionToTextBoxGalleryToolStripMenuItem});
-            this.cmsTextBoxItems.Text = "";
             // 
             // drawTextBoxToolStripMenuItem
             // 
@@ -879,7 +843,6 @@ namespace OutlookMailClone
             // 
             this.cmsDropCapItems.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.dropCapOptionsToolStripMenuItem});
-            this.cmsDropCapItems.Text = "";
             // 
             // dropCapOptionsToolStripMenuItem
             // 
@@ -896,7 +859,6 @@ namespace OutlookMailClone
             this.cmsEquationItems.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.insertNewEquationToolStripMenuItem,
             this.saveTextTToolStripMenuItem});
-            this.cmsEquationItems.Text = "";
             // 
             // insertNewEquationToolStripMenuItem
             // 
@@ -916,7 +878,6 @@ namespace OutlookMailClone
             // 
             this.cmsQuickPartsItems.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.saveSelectionToQuickPartsGalleryToolStripMenuItem});
-            this.cmsQuickPartsItems.Text = "";
             // 
             // saveSelectionToQuickPartsGalleryToolStripMenuItem
             // 
@@ -931,7 +892,6 @@ namespace OutlookMailClone
             // 
             this.cmsSymbolItems.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.moreSymbolsToolStripMenuItem});
-            this.cmsSymbolItems.Text = "";
             // 
             // moreSymbolsToolStripMenuItem
             // 
@@ -947,7 +907,6 @@ namespace OutlookMailClone
             // 
             this.cmsShapesItems.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.newDrawingCanvasToolStripMenuItem});
-            this.cmsShapesItems.Text = "";
             // 
             // newDrawingCanvasToolStripMenuItem
             // 
@@ -966,7 +925,6 @@ namespace OutlookMailClone
             this.moreThemesOnMicrosoftOfficeToolStripMenuItem,
             this.browseForThemesToolStripMenuItem,
             this.saveCurrentThemeToolStripMenuItem});
-            this.cmsThemesItems.Text = "";
             // 
             // resetToThemeFromTemplateToolStripMenuItem
             // 
@@ -998,15 +956,10 @@ namespace OutlookMailClone
             this.kryptonContextMenuSeparator3,
             this.moreColorsToolStripMenuItem,
             this.fillEffectsToolStripMenuItem});
-            this.cmsPageColorItems.Text = "";
             // 
             // noColorToolStripMenuItem
             // 
             this.noColorToolStripMenuItem.Text = "No Color";
-            // 
-            // kryptonContextMenuSeparator3
-            // 
-            this.kryptonContextMenuSeparator3.Text = "";
             // 
             // moreColorsToolStripMenuItem
             // 
@@ -1015,10 +968,6 @@ namespace OutlookMailClone
             // fillEffectsToolStripMenuItem
             // 
             this.fillEffectsToolStripMenuItem.Text = "Fill Effects...";
-            // 
-            // toolStripMenuItem6
-            // 
-            this.toolStripMenuItem6.Text = "";
             // 
             // cmsUseVotingButtons
             // 
@@ -1033,7 +982,6 @@ namespace OutlookMailClone
             this.yesNoMaybeToolStripMenuItem,
             this.kryptonContextMenuSeparator10,
             this.customToolStripMenuItem2});
-            this.cmsUseVotingButtonsItems.Text = "";
             // 
             // approveRejectToolStripMenuItem
             // 
@@ -1047,17 +995,9 @@ namespace OutlookMailClone
             // 
             this.yesNoMaybeToolStripMenuItem.Text = "Yes; No; Maybe";
             // 
-            // kryptonContextMenuSeparator10
-            // 
-            this.kryptonContextMenuSeparator10.Text = "";
-            // 
             // customToolStripMenuItem2
             // 
             this.customToolStripMenuItem2.Text = "Custom...";
-            // 
-            // toolStripMenuItem7
-            // 
-            this.toolStripMenuItem7.Text = "";
             // 
             // cmsSaveSentItem
             // 
@@ -1071,16 +1011,11 @@ namespace OutlookMailClone
             this.kryptonContextMenuSeparator4,
             this.useDefaultFolderToolStripMenuItem,
             this.dotNotSaveToolStripMenuItem});
-            this.cmsSaveSentItemItems.Text = "";
             // 
             // otherFolderToolStripMenuItem
             // 
             this.otherFolderToolStripMenuItem.Image = global::OutlookMailClone.Properties.Resources.OtherFolderSmall;
             this.otherFolderToolStripMenuItem.Text = "Other Folder...";
-            // 
-            // kryptonContextMenuSeparator4
-            // 
-            this.kryptonContextMenuSeparator4.Text = "";
             // 
             // useDefaultFolderToolStripMenuItem
             // 
@@ -1091,10 +1026,6 @@ namespace OutlookMailClone
             // dotNotSaveToolStripMenuItem
             // 
             this.dotNotSaveToolStripMenuItem.Text = "Dot Not Save";
-            // 
-            // toolStripMenuItem8
-            // 
-            this.toolStripMenuItem8.Text = "";
             // 
             // cmsChangeCase
             // 
@@ -1109,7 +1040,6 @@ namespace OutlookMailClone
             this.uPPERCASEToolStripMenuItem,
             this.capitalizeEachWordToolStripMenuItem,
             this.tOGGLECASEToolStripMenuItem});
-            this.cmsChangeCaseItems.Text = "";
             // 
             // sentenceCaseToolStripMenuItem
             // 
@@ -1143,7 +1073,6 @@ namespace OutlookMailClone
             this.spacingToolStripMenuItem,
             this.doubleSpacingToolStripMenuItem,
             this.paragraphToolStripMenuItem});
-            this.cmsSpacingItems.Text = "";
             // 
             // singleSpacingToolStripMenuItem
             // 
@@ -1193,7 +1122,6 @@ namespace OutlookMailClone
             this.drawTableToolStripMenuItem1,
             this.viewGridlinesToolStripMenuItem,
             this.bordersAndShadingToolStripMenuItem});
-            this.cmsBottomBorderItems.Text = "";
             // 
             // bottomBorderToolStripMenuItem
             // 
@@ -1215,10 +1143,6 @@ namespace OutlookMailClone
             this.rightBorderToolStripMenuItem.Image = global::OutlookMailClone.Properties.Resources.RightBorder;
             this.rightBorderToolStripMenuItem.Text = "Right Border";
             // 
-            // kryptonContextMenuSeparator6
-            // 
-            this.kryptonContextMenuSeparator6.Text = "";
-            // 
             // noBorderToolStripMenuItem
             // 
             this.noBorderToolStripMenuItem.Image = global::OutlookMailClone.Properties.Resources.NoBorder;
@@ -1238,10 +1162,6 @@ namespace OutlookMailClone
             // 
             this.insideBordersToolStripMenuItem.Image = global::OutlookMailClone.Properties.Resources.InsideBorder;
             this.insideBordersToolStripMenuItem.Text = "Inside Borders";
-            // 
-            // kryptonContextMenuSeparator7
-            // 
-            this.kryptonContextMenuSeparator7.Text = "";
             // 
             // insideHorizontalBorderToolStripMenuItem
             // 
@@ -1263,18 +1183,10 @@ namespace OutlookMailClone
             this.diagonalUpBorderToolStripMenuItem.Image = global::OutlookMailClone.Properties.Resources.DiagonalUpBorder;
             this.diagonalUpBorderToolStripMenuItem.Text = "Diagonal Up Border";
             // 
-            // kryptonContextMenuSeparator8
-            // 
-            this.kryptonContextMenuSeparator8.Text = "";
-            // 
             // horizontalLineToolStripMenuItem
             // 
             this.horizontalLineToolStripMenuItem.Image = global::OutlookMailClone.Properties.Resources.HorizontalLineSmall;
             this.horizontalLineToolStripMenuItem.Text = "Horizontal Line";
-            // 
-            // kryptonContextMenuSeparator9
-            // 
-            this.kryptonContextMenuSeparator9.Text = "";
             // 
             // drawTableToolStripMenuItem1
             // 
@@ -1291,22 +1203,6 @@ namespace OutlookMailClone
             this.bordersAndShadingToolStripMenuItem.Image = global::OutlookMailClone.Properties.Resources.BordersAndShading;
             this.bordersAndShadingToolStripMenuItem.Text = "Borders and Shading...";
             // 
-            // toolStripMenuItem9
-            // 
-            this.toolStripMenuItem9.Text = "";
-            // 
-            // toolStripMenuItem10
-            // 
-            this.toolStripMenuItem10.Text = "";
-            // 
-            // toolStripMenuItem11
-            // 
-            this.toolStripMenuItem11.Text = "";
-            // 
-            // toolStripMenuItem12
-            // 
-            this.toolStripMenuItem12.Text = "";
-            // 
             // cmsChangeStyles
             // 
             this.cmsChangeStyles.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
@@ -1320,7 +1216,6 @@ namespace OutlookMailClone
             this.fontsToolStripMenuItem,
             this.kryptonContextMenuSeparator5,
             this.setAsDefaultToolStripMenuItem});
-            this.cmsChangeStylesItems.Text = "";
             // 
             // styleSetToolStripMenuItem
             // 
@@ -1337,17 +1232,9 @@ namespace OutlookMailClone
             this.fontsToolStripMenuItem.Image = global::OutlookMailClone.Properties.Resources.FontsSmall;
             this.fontsToolStripMenuItem.Text = "Fonts";
             // 
-            // kryptonContextMenuSeparator5
-            // 
-            this.kryptonContextMenuSeparator5.Text = "";
-            // 
             // setAsDefaultToolStripMenuItem
             // 
             this.setAsDefaultToolStripMenuItem.Text = "Set as Default";
-            // 
-            // toolStripMenuItem13
-            // 
-            this.toolStripMenuItem13.Text = "";
             // 
             // cmsQuickStyles
             // 
@@ -1360,7 +1247,6 @@ namespace OutlookMailClone
             this.saveSelectionAsNewStyleToolStripMenuItem,
             this.clearFormattingToolStripMenuItem,
             this.applyStylesToolStripMenuItem});
-            this.cmsQuickStylesItems.Text = "";
             // 
             // saveSelectionAsNewStyleToolStripMenuItem
             // 
@@ -1386,7 +1272,6 @@ namespace OutlookMailClone
             this.cmsFindItems.Items.AddRange(new Krypton.Toolkit.KryptonContextMenuItemBase[] {
             this.findToolStripMenuItem,
             this.goToToolStripMenuItem});
-            this.cmsFindItems.Text = "";
             // 
             // findToolStripMenuItem
             // 
@@ -1408,7 +1293,6 @@ namespace OutlookMailClone
             this.selectAllToolStripMenuItem,
             this.selectObjectsToolStripMenuItem,
             this.selectTextWithSimilarFormattingToolStripMenuItem});
-            this.cmsSelectItems.Text = "";
             // 
             // selectAllToolStripMenuItem
             // 
@@ -1520,7 +1404,6 @@ namespace OutlookMailClone
             // 
             // kryptonContextMenuSeparator11
             // 
-            this.kryptonContextMenuSeparator11.Text = "";
             // 
             // kryptonContextMenuItem3
             // 
@@ -1542,7 +1425,6 @@ namespace OutlookMailClone
             this.kryptonContextMenuHeading1,
             this.kryptonContextMenuItem10});
             this.kryptonContextMenuItems1.StandardStyle = false;
-            this.kryptonContextMenuItems1.Text = "";
             // 
             // kryptonContextMenuHeading1
             // 
@@ -1567,7 +1449,6 @@ namespace OutlookMailClone
             // 
             // kryptonContextMenuSeparator13
             // 
-            this.kryptonContextMenuSeparator13.Text = "";
             // 
             // kryptonContextMenuItem7
             // 
@@ -1589,7 +1470,6 @@ namespace OutlookMailClone
             this.kryptonContextMenuItem13,
             this.kryptonContextMenuItem14});
             this.kryptonContextMenuItems2.StandardStyle = false;
-            this.kryptonContextMenuItems2.Text = "";
             // 
             // kryptonContextMenuHeading2
             // 
@@ -1622,7 +1502,6 @@ namespace OutlookMailClone
             // 
             // kryptonContextMenuSeparator15
             // 
-            this.kryptonContextMenuSeparator15.Text = "";
             // 
             // kryptonContextMenuItems3
             // 
@@ -1631,7 +1510,6 @@ namespace OutlookMailClone
             this.kryptonContextMenuHeading3,
             this.kryptonContextMenuItem15});
             this.kryptonContextMenuItems3.StandardStyle = false;
-            this.kryptonContextMenuItems3.Text = "";
             // 
             // kryptonContextMenuHeading3
             // 
@@ -1645,7 +1523,6 @@ namespace OutlookMailClone
             // 
             // kryptonContextMenuSeparator12
             // 
-            this.kryptonContextMenuSeparator12.Text = "";
             // 
             // kryptonContextMenuItem8
             // 

--- a/Source/Krypton Ribbon Examples/Outlook Mail Clone/Outlook Mail Clone 2022.csproj
+++ b/Source/Krypton Ribbon Examples/Outlook Mail Clone/Outlook Mail Clone 2022.csproj
@@ -38,8 +38,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/Quick Access Toolbar/Quick Access Toolbar 2022.csproj
+++ b/Source/Krypton Ribbon Examples/Quick Access Toolbar/Quick Access Toolbar 2022.csproj
@@ -25,8 +25,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/Ribbon + Navigator + Workspace/Ribbon + Navigator + Workspace 2022.csproj
+++ b/Source/Krypton Ribbon Examples/Ribbon + Navigator + Workspace/Ribbon + Navigator + Workspace 2022.csproj
@@ -25,10 +25,10 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.WorkSpace.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/Ribbon Controls/Ribbon Controls 2022.csproj
+++ b/Source/Krypton Ribbon Examples/Ribbon Controls/Ribbon Controls 2022.csproj
@@ -39,8 +39,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/Ribbon Gallery/Ribbon Gallery 2022.csproj
+++ b/Source/Krypton Ribbon Examples/Ribbon Gallery/Ribbon Gallery 2022.csproj
@@ -25,8 +25,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Ribbon Examples/Ribbon ToolTips/Ribbon ToolTips 2022.csproj
+++ b/Source/Krypton Ribbon Examples/Ribbon ToolTips/Ribbon ToolTips 2022.csproj
@@ -25,8 +25,8 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/ButtonSpec Playground/ButtonSpec Playground 2022.csproj
+++ b/Source/Krypton Toolkit Examples/ButtonSpec Playground/ButtonSpec Playground 2022.csproj
@@ -33,7 +33,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Child Control Stack/Child Control Stack 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Child Control Stack/Child Control Stack 2022.csproj
@@ -27,7 +27,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Custom Control using Palettes/Custom Control using Palettes 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Custom Control using Palettes/Custom Control using Palettes 2022.csproj
@@ -32,7 +32,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Custom Control using Renderers/Custom Control using Renderers 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Custom Control using Renderers/Custom Control using Renderers 2022.csproj
@@ -32,7 +32,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Expanding HeaderGroups (DockStyle)/Expanding HeaderGroups (DockStyle) 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Expanding HeaderGroups (DockStyle)/Expanding HeaderGroups (DockStyle) 2022.csproj
@@ -27,7 +27,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Splitters)/Expanding HeaderGroups (Splitters) 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Splitters)/Expanding HeaderGroups (Splitters) 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Stack)/Expanding HeaderGroups (Stack) 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Expanding HeaderGroups (Stack)/Expanding HeaderGroups (Stack) 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Input Form/Input Form 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Input Form/Input Form 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/IntegratedToolbarExample/IntegratedToolbarExample 2022.csproj
+++ b/Source/Krypton Toolkit Examples/IntegratedToolbarExample/IntegratedToolbarExample 2022.csproj
@@ -20,7 +20,7 @@
 <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Krypton Scrollbars/Krypton Scrollbars 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Krypton Scrollbars/Krypton Scrollbars 2022.csproj
@@ -21,7 +21,7 @@
 <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Krypton Theme Playground/Krypton Theme Playground 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Krypton Theme Playground/Krypton Theme Playground 2022.csproj
@@ -24,7 +24,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Krypton Theme Selector/Krypton Theme Selector 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Krypton Theme Selector/Krypton Theme Selector 2022.csproj
@@ -22,7 +22,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Krypton UAC Button/Krypton UAC Button 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Krypton UAC Button/Krypton UAC Button 2022.csproj
@@ -28,7 +28,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonAboutBox Example/KryptonAboutBox Example 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonAboutBox Example/KryptonAboutBox Example 2022.csproj
@@ -23,7 +23,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonAboutToolkit Example/KryptonAboutToolkit Example 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonAboutToolkit Example/KryptonAboutToolkit Example 2022.csproj
@@ -23,7 +23,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonBorderEdge Examples/KryptonBorderEdge Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonBorderEdge Examples/KryptonBorderEdge Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonBreadCrumb Examples/KryptonBreadCrumb Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonBreadCrumb Examples/KryptonBreadCrumb Examples 2022.csproj
@@ -39,7 +39,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonButton Examples/KryptonButton Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonButton Examples/KryptonButton Examples 2022.csproj
@@ -25,7 +25,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonCheckBox Examples/KryptonCheckBox Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonCheckBox Examples/KryptonCheckBox Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonCheckButton Examples/KryptonCheckButton Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonCheckButton Examples/KryptonCheckButton Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonCheckSet Examples/KryptonCheckSet Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonCheckSet Examples/KryptonCheckSet Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonCheckedListBox Examples/KryptonCheckedListBox Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonCheckedListBox Examples/KryptonCheckedListBox Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonColorButton Examples/KryptonColorButton Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonColorButton Examples/KryptonColorButton Examples 2022.csproj
@@ -27,7 +27,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonColorDialog Example/KryptonColorDialog Example 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonColorDialog Example/KryptonColorDialog Example 2022.csproj
@@ -17,7 +17,7 @@
 <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonComboBox Examples/KryptonComboBox Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonComboBox Examples/KryptonComboBox Examples 2022.csproj
@@ -27,7 +27,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonCommand Examples/KryptonCommand Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonCommand Examples/KryptonCommand Examples 2022.csproj
@@ -27,7 +27,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonCommandLinkButton Examples/KryptonCommandLinkButton Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonCommandLinkButton Examples/KryptonCommandLinkButton Examples 2022.csproj
@@ -31,7 +31,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonContextMenu Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonContextMenu Examples/Form1.cs
@@ -5,7 +5,7 @@
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
  *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), tobitege et al. 2017 - 2025. All rights reserved.
  *
  */
 #endregion

--- a/Source/Krypton Toolkit Examples/KryptonContextMenu Examples/Form1.cs
+++ b/Source/Krypton Toolkit Examples/KryptonContextMenu Examples/Form1.cs
@@ -1,12 +1,12 @@
 ﻿#region BSD License
 /*
- * 
+ *
  * Original BSD 3-Clause License (https://github.com/ComponentFactory/Krypton/blob/master/LICENSE)
  *  © Component Factory Pty Ltd, 2006 - 2016, (Version 4.5.0.0) All rights reserved.
- * 
+ *
  *  New BSD 3-Clause License (https://github.com/Krypton-Suite/Standard-Toolkit/blob/master/LICENSE)
- *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved. 
- *  
+ *  Modifications by Peter Wagner(aka Wagnerp) & Simon Coghlan(aka Smurf-IV), et al. 2017 - 2024. All rights reserved.
+ *
  */
 #endregion
 
@@ -24,7 +24,6 @@ namespace KryptonContextMenuExamples
         private void Form1_Load(object sender, EventArgs e)
         {
             KryptonContextMenuItemBase item = kryptonContextMenuItems1[0];
-            var name = item.Text;
             comboBoxH.SelectedIndex = 2;
             comboBoxV.SelectedIndex = 1;
             kryptonThemeComboBox1.Items.Remove(kryptonThemeComboBox1.Items.Count - 1);    // Remove the "Custom" option

--- a/Source/Krypton Toolkit Examples/KryptonContextMenu Examples/KryptonContextMenu Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonContextMenu Examples/KryptonContextMenu Examples 2022.csproj
@@ -27,7 +27,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonDataGridView Examples/KryptonDataGridView Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonDataGridView Examples/KryptonDataGridView Examples 2022.csproj
@@ -38,7 +38,7 @@
   <Choose>
     <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
       <ItemGroup>
-        <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+        <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonDateTimePicker Examples/KryptonDateTimePicker Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonDateTimePicker Examples/KryptonDateTimePicker Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonDomainUpDown Examples/KryptonDomainUpDown Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonDomainUpDown Examples/KryptonDomainUpDown Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonDropButton Examples/Form1.Designer.cs
+++ b/Source/Krypton Toolkit Examples/KryptonDropButton Examples/Form1.Designer.cs
@@ -158,7 +158,6 @@ namespace KryptonDropButtonExamples
             this.kryptonContextMenuItem1,
             this.kryptonContextMenuItem2,
             this.kryptonContextMenuItem3});
-            this.kryptonContextMenuItems1.Text = "";
             // 
             // kryptonContextMenuItem1
             // 
@@ -535,7 +534,6 @@ namespace KryptonDropButtonExamples
             this.kryptonContextMenuItem13,
             this.kryptonContextMenuItem14,
             this.kryptonContextMenuItem15});
-            this.kryptonContextMenuItems5.Text = "";
             // 
             // kryptonContextMenuItem13
             // 

--- a/Source/Krypton Toolkit Examples/KryptonDropButton Examples/KryptonDropButton Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonDropButton Examples/KryptonDropButton Examples 2022.csproj
@@ -39,7 +39,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonFolderBrowserDialog Example/KryptonFolderBrowserDialog Example 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonFolderBrowserDialog Example/KryptonFolderBrowserDialog Example 2022.csproj
@@ -15,7 +15,7 @@
 <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonFontDialog Example/KryptonFontDialog Example 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonFontDialog Example/KryptonFontDialog Example 2022.csproj
@@ -16,7 +16,7 @@
 <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonForm Examples/KryptonForm Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonForm Examples/KryptonForm Examples 2022.csproj
@@ -39,7 +39,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonFormFading Example/KryptonFormFading Example 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonFormFading Example/KryptonFormFading Example 2022.csproj
@@ -30,7 +30,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonGroup Examples/KryptonGroup Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonGroup Examples/KryptonGroup Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonGroupBox Examples/KryptonGroupBox Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonGroupBox Examples/KryptonGroupBox Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonHeader Examples/KryptonHeader Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonHeader Examples/KryptonHeader Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonHeaderGroup Examples/KryptonHeaderGroup Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonHeaderGroup Examples/KryptonHeaderGroup Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonHelpIcon Examples/KryptonHelpIcon Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonHelpIcon Examples/KryptonHelpIcon Examples 2022.csproj
@@ -23,7 +23,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonInputBox Examples/KryptonInputBox Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonInputBox Examples/KryptonInputBox Examples 2022.csproj
@@ -27,7 +27,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonLabel Examples/KryptonLabel Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonLabel Examples/KryptonLabel Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonLinkLabel Examples/KryptonLinkLabel Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonLinkLabel Examples/KryptonLinkLabel Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonListBox Examples/KryptonListBox Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonListBox Examples/KryptonListBox Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonListView Examples/KryptonListView Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonListView Examples/KryptonListView Examples 2022.csproj
@@ -22,7 +22,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonMaskedTextBox Examples/KryptonMaskedTextBox Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonMaskedTextBox Examples/KryptonMaskedTextBox Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonMessageBox Examples/KryptonMessageBox Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonMessageBox Examples/KryptonMessageBox Examples 2022.csproj
@@ -42,7 +42,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonMonthCalendar Examples/KryptonMonthCalendar Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonMonthCalendar Examples/KryptonMonthCalendar Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonNumericUpDown Examples/KryptonNumericUpDown Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonNumericUpDown Examples/KryptonNumericUpDown Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonOpenFileDialog Example/KryptonOpenFileDialog Example 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonOpenFileDialog Example/KryptonOpenFileDialog Example 2022.csproj
@@ -17,7 +17,7 @@
 <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonOutlookGrid Example/KryptonOutlookGrid Example 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonOutlookGrid Example/KryptonOutlookGrid Example 2022.csproj
@@ -19,7 +19,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonPalette Examples/KryptonPalette Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonPalette Examples/KryptonPalette Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonPanel Examples/KryptonPanel Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonPanel Examples/KryptonPanel Examples 2022.csproj
@@ -27,7 +27,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonPrintDialog Example/KryptonPrintDialog Example 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonPrintDialog Example/KryptonPrintDialog Example 2022.csproj
@@ -17,7 +17,7 @@
 <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/KryptonProgressbar Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonProgressbar Examples/KryptonProgressbar Examples 2022.csproj
@@ -24,7 +24,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonPropertyGridExample/KryptonPropertyGridExample 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonPropertyGridExample/KryptonPropertyGridExample 2022.csproj
@@ -28,7 +28,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonRadioButton Examples/KryptonRadioButton Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonRadioButton Examples/KryptonRadioButton Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonRichTextBox Examples/KryptonRichTextBox Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonRichTextBox Examples/KryptonRichTextBox Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonSaveFileDialog Example/KryptonSaveFileDialog Example 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonSaveFileDialog Example/KryptonSaveFileDialog Example 2022.csproj
@@ -17,7 +17,7 @@
 <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonScrollbar Examples/KryptonScrollbar Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonScrollbar Examples/KryptonScrollbar Examples 2022.csproj
@@ -23,7 +23,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonSeparator Examples/KryptonSeparator Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonSeparator Examples/KryptonSeparator Examples 2022.csproj
@@ -28,7 +28,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonSplitContainer Examples/KryptonSplitContainer Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonSplitContainer Examples/KryptonSplitContainer Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonStringCollectionEditor Examples 2022/KryptonStringCollectionEditor Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonStringCollectionEditor Examples 2022/KryptonStringCollectionEditor Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonTableLayoutPanel Examples/KryptonTableLayoutPanel Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonTableLayoutPanel Examples/KryptonTableLayoutPanel Examples 2022.csproj
@@ -39,7 +39,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonTaskDialog Examples/KryptonTaskDialog Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonTaskDialog Examples/KryptonTaskDialog Examples 2022.csproj
@@ -27,7 +27,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonTextBox Examples/KryptonTextBox Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonTextBox Examples/KryptonTextBox Examples 2022.csproj
@@ -27,7 +27,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonToastNotification Examples/KryptonToastNotification Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonToastNotification Examples/KryptonToastNotification Examples 2022.csproj
@@ -28,7 +28,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonTrackBar Examples/KryptonTrackBar Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonTrackBar Examples/KryptonTrackBar Examples 2022.csproj
@@ -28,7 +28,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonTreeView Examples/KryptonTreeView Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonTreeView Examples/KryptonTreeView Examples 2022.csproj
@@ -27,7 +27,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonWebBrowser Example/KryptonWebBrowser Example 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonWebBrowser Example/KryptonWebBrowser Example 2022.csproj
@@ -37,7 +37,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/KryptonWrapLabel Examples/KryptonWrapLabel Examples 2022.csproj
+++ b/Source/Krypton Toolkit Examples/KryptonWrapLabel Examples/KryptonWrapLabel Examples 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/MDI Application/MDI Application 2022.csproj
+++ b/Source/Krypton Toolkit Examples/MDI Application/MDI Application 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/SystemThemedForms/SystemThemedForms 2022.csproj
+++ b/Source/Krypton Toolkit Examples/SystemThemedForms/SystemThemedForms 2022.csproj
@@ -21,7 +21,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Test Clip Base/Test Clip Base 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Test Clip Base/Test Clip Base 2022.csproj
@@ -22,7 +22,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Test Combo Domain Numeric/Test Combo Domain Numeric 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Test Combo Domain Numeric/Test Combo Domain Numeric 2022.csproj
@@ -18,7 +18,7 @@
 <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Test MessageBox Clipping 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Test MessageBox Clipping/Test MessageBox Clipping 2022.csproj
@@ -21,7 +21,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Test Text Clipping/Test Text Clipping 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Test Text Clipping/Test Text Clipping 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Three Pane Application (Basic)/Three Pane Application (Basic) 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Three Pane Application (Basic)/Three Pane Application (Basic) 2022.csproj
@@ -26,7 +26,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Toolkit Examples/Three Pane Application (Extended)/Three Pane Application (Extended) 2022.csproj
+++ b/Source/Krypton Toolkit Examples/Three Pane Application (Extended)/Three Pane Application (Extended) 2022.csproj
@@ -28,7 +28,7 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Workspace Examples/Advanced Page Drag + Drop/Advanced Page Drag + Drop 2022.csproj
+++ b/Source/Krypton Workspace Examples/Advanced Page Drag + Drop/Advanced Page Drag + Drop 2022.csproj
@@ -22,9 +22,9 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Workspace.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Workspace Examples/Basic Page Drag + Drop/Basic Page Drag + Drop 2022.csproj
+++ b/Source/Krypton Workspace Examples/Basic Page Drag + Drop/Basic Page Drag + Drop 2022.csproj
@@ -20,9 +20,9 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Workspace.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Workspace Examples/Cell Maximize + Restore/Cell Maximize + Restore 2022.csproj
+++ b/Source/Krypton Workspace Examples/Cell Maximize + Restore/Cell Maximize + Restore 2022.csproj
@@ -20,9 +20,9 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Workspace.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Workspace Examples/Memo Editor/Form1.Designer.cs
+++ b/Source/Krypton Workspace Examples/Memo Editor/Form1.Designer.cs
@@ -138,10 +138,6 @@
             this.appButtonOpenMemo.Text = "&Open";
             this.appButtonOpenMemo.Click += new System.EventHandler(this.buttonOpenMemo_Click);
             // 
-            // appButtonSep1
-            // 
-            this.appButtonSep1.Text = "";
-            // 
             // appButtonSaveMemo
             // 
             this.appButtonSaveMemo.Text = "&Save";
@@ -156,10 +152,6 @@
             // 
             this.appButtonSaveAllMemo.Text = "Save A&ll";
             this.appButtonSaveAllMemo.Click += new System.EventHandler(this.buttonSaveAllMemo_Click);
-            // 
-            // appButtonSep2
-            // 
-            this.appButtonSep2.Text = "";
             // 
             // appButtonCloseMemo
             // 

--- a/Source/Krypton Workspace Examples/Memo Editor/Memo Editor 2022.csproj
+++ b/Source/Krypton Workspace Examples/Memo Editor/Memo Editor 2022.csproj
@@ -20,10 +20,10 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Ribbon.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Workspace.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Ribbon" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Workspace Examples/Workspace Cell Layout/Workspace Cell Layout 2022.csproj
+++ b/Source/Krypton Workspace Examples/Workspace Cell Layout/Workspace Cell Layout 2022.csproj
@@ -20,9 +20,9 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Workspace.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Workspace Examples/Workspace Cell Modes/Workspace Cell Modes 2022.csproj
+++ b/Source/Krypton Workspace Examples/Workspace Cell Modes/Workspace Cell Modes 2022.csproj
@@ -20,9 +20,9 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Workspace.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/Source/Krypton Workspace Examples/Workspace Persistence/Workspace Persistence 2022.csproj
+++ b/Source/Krypton Workspace Examples/Workspace Persistence/Workspace Persistence 2022.csproj
@@ -21,9 +21,9 @@
     <Choose>
         <When Condition="'$(SolutionName.Endswith(`Nuget`))'">
             <ItemGroup>
-                <PackageReference Include="Krypton.Toolkit.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Navigator.Canary" Version="90.23.12.352-beta" />
-                <PackageReference Include="Krypton.Workspace.Canary" Version="90.23.12.352-beta" />
+                <PackageReference Include="Krypton.Docking" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Navigator" Version="95.25.8.235" />
+                <PackageReference Include="Krypton.Workspace" Version="95.25.8.235" />
             </ItemGroup>
         </When>
         <Otherwise>

--- a/app.core.manifest
+++ b/app.core.manifest
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/app.net4x.manifest
+++ b/app.net4x.manifest
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/build-all.cmd
+++ b/build-all.cmd
@@ -1,0 +1,133 @@
+@echo off
+setlocal EnableExtensions EnableDelayedExpansion
+
+rem Usage: build-all.cmd [Configuration] [Mode] [Rebuild]
+rem   Configuration: Debug or Release (default: Release)
+rem   Mode: all | nuget | dev (default: all)
+rem   Rebuild: on | off (default: on)
+
+if "%~1"=="" if "%~2"=="" if "%~3"=="" (
+  echo.
+  echo Usage: build-all.cmd [Configuration] [Mode] [Rebuild]
+  echo   Configuration: Debug or Release ^(default: Release^)
+  echo   Mode: all ^| nuget ^| dev ^(default: all^)
+  echo   Rebuild: on ^| off ^(default: on^)
+  echo.
+  echo Examples:
+  echo   build-all.cmd Release all on
+  echo   build-all.cmd Debug nuget off
+  exit /b 0
+)
+
+set "CONFIG=%~1"
+if "%CONFIG%"=="" set "CONFIG=Release"
+set "MODE=%~2"
+if "%MODE%"=="" set "MODE=all"
+set "REBUILD=%~3"
+if /i "%REBUILD%"=="" set "REBUILD=on"
+
+set "TARGET=/t:Build"
+if /i "%REBUILD%"=="on" set "TARGET=/t:Rebuild"
+
+echo ======================================================
+echo Building solutions - Configuration: %CONFIG% - Mode: %MODE% - Rebuild: %REBUILD%
+echo Repo: %CD%
+echo ======================================================
+
+set "MSBUILD="
+
+rem Prefer explicit Visual Studio 2022 MSBuild locations (version 17.x only)
+if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\MSBuild.exe" set "MSBUILD=%ProgramFiles%\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\MSBuild.exe"
+if not defined MSBUILD if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe" set "MSBUILD=%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\MSBuild.exe"
+if not defined MSBUILD if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe" set "MSBUILD=%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Current\Bin\MSBuild.exe"
+if not defined MSBUILD if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" set "MSBUILD=%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe"
+if not defined MSBUILD if exist "%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe" set "MSBUILD=%ProgramFiles%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe"
+
+rem Fallback to vswhere discovery, restricted to VS 2022 (17.x)
+if not defined MSBUILD (
+  set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+  if exist "%VSWHERE%" (
+    for /f "usebackq delims=" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.Component.MSBuild -version "[17.0,18.0)" -find MSBuild\**\Bin\MSBuild.exe`) do set "MSBUILD=%%i"
+    if not defined MSBUILD (
+      for /f "usebackq delims=" %%i in (`"%VSWHERE%" -latest -prerelease -products * -requires Microsoft.Component.MSBuild -version "[17.0,18.0)" -find MSBuild\**\Bin\MSBuild.exe`) do set "MSBUILD=%%i"
+    )
+  )
+)
+
+if defined MSBUILD (
+  if exist "%MSBUILD%" (
+    echo Using MSBuild: %MSBUILD%
+  ) else (
+    echo ERROR: Resolved MSBuild path not found: %MSBUILD%
+    exit /b 1
+  )
+) else (
+  echo ERROR: Visual Studio 2022 MSBuild not found. Ensure VS 2022 Build Tools are installed.
+  exit /b 1
+)
+
+set "LOGDIR=Binaries\BuildLogs"
+if not exist "%LOGDIR%" mkdir "%LOGDIR%" >nul 2>&1
+set "FAILED_LOG=%LOGDIR%\_failed.txt"
+if exist "%FAILED_LOG%" del /q "%FAILED_LOG%" >nul 2>&1
+
+set BUILD_ERRORS=0
+
+if /i "%MODE%"=="nuget" goto :BUILD_NUGET
+if /i "%MODE%"=="dev" goto :BUILD_DEV
+
+:BUILD_NUGET
+echo.
+echo === Building NuGet solutions ===
+for /f "delims=" %%F in ('dir /b /s "* - Nuget.sln"') do (
+  echo.
+  echo --- Building: %%~fF ---
+  "%MSBUILD%" "%%~fF" /m /nologo /v:quiet /clp:Summary;ShowTimestamp /restore %TARGET% /p:Configuration=%CONFIG% /bl:"%LOGDIR%\%%~nF.binlog"
+  if errorlevel 1 (
+    echo !!! FAILED: %%~fF
+    echo %%~fF>>"%FAILED_LOG%"
+    set /a BUILD_ERRORS+=1
+  ) else (
+    echo SUCCESS: %%~fF
+  )
+)
+if /i "%MODE%"=="nuget" goto :SUMMARY
+
+:BUILD_DEV
+echo.
+echo === Building Dev solutions ===
+set "EXPECTED_ST_ROOT=%CD%\..\Standard-Toolkit"
+if not exist "%EXPECTED_ST_ROOT%" (
+  echo WARNING: Expected Standard-Toolkit repo at "%EXPECTED_ST_ROOT%" for Dev solutions.
+)
+for /f "delims=" %%F in ('dir /b /s "* - Dev.sln"') do (
+  echo.
+  echo --- Building: %%~fF ---
+  "%MSBUILD%" "%%~fF" /m /nologo /v:quiet /clp:Summary;ShowTimestamp /restore %TARGET% /p:Configuration=%CONFIG% /bl:"%LOGDIR%\%%~nF.binlog"
+  if errorlevel 1 (
+    echo !!! FAILED: %%~fF
+    echo %%~fF>>"%FAILED_LOG%"
+    set /a BUILD_ERRORS+=1
+  ) else (
+    echo SUCCESS: %%~fF
+  )
+)
+
+:SUMMARY
+echo.
+echo ======================================================
+echo Build finished with %BUILD_ERRORS% error(s).
+echo Logs: %LOGDIR%
+if exist "%FAILED_LOG%" (
+  echo.
+  echo Failed solutions:
+  type "%FAILED_LOG%"
+  echo.
+  echo See binlogs above for details per solution.
+)
+if not exist "%FAILED_LOG%" (
+  echo All solutions built successfully.
+)
+echo ======================================================
+
+exit /b %BUILD_ERRORS%

--- a/build-all.md
+++ b/build-all.md
@@ -1,0 +1,191 @@
+This guide includes sections in English, German, Spanish, and Simplified Chinese.
+
+## English
+
+### Overview
+- Script: `build-all.cmd`
+- Purpose: Build all solutions in this repo (NuGet- and Dev-based) with MSBuild, produce concise console output, and write binlogs.
+
+### Prerequisites
+- Visual Studio 2022 (any edition) or VS 2022 Build Tools (required).
+- .NET SDKs: net8.0 and net9.0 as needed by solutions.
+- For Dev solutions: sibling repo `..\Standard-Toolkit` on a matching branch.
+
+### Usage
+```
+build-all.cmd [Configuration] [Mode] [Rebuild]
+```
+- Configuration: `Debug` or `Release` (default: `Release`)
+- Mode: `all` | `nuget` | `dev` (default: `all`)
+- Rebuild: `on` | `off` (default: `on`)
+
+### Examples
+- Build everything in Release with Rebuild (default):
+```
+build-all.cmd
+```
+- NuGet-only, Debug, Rebuild off (incremental):
+```
+build-all.cmd Debug nuget off
+```
+- Dev-only, Release, Rebuild on:
+```
+build-all.cmd Release dev on
+```
+
+### Output & Logs
+- Binlogs: `Binaries\BuildLogs\<solution-name>.binlog`
+- Failures summary: `Binaries\BuildLogs\_failed.txt` (printed at end if present)
+- Console output: quiet with summary and timestamps
+
+### Inspecting .binlog
+- Recommended viewer: MSBuild Structured Log Viewer (`https://msbuildlog.com`).
+- Or open `.binlog` directly in Visual Studio (File → Open → File).
+
+### Notes
+- Only Visual Studio 2022 installations are used; older MSBuild versions are ignored.
+- Dev builds warn if `..\Standard-Toolkit` is not present.
+
+---
+
+## Deutsch
+
+### Übersicht
+- Skript: `build-all.cmd`
+- Zweck: Alle Lösungen (NuGet und Dev) mit MSBuild bauen, konsolen­ausgabe minimieren, Binlogs schreiben.
+
+### Voraussetzungen
+- Visual Studio 2022 (beliebige Edition) oder VS 2022 Build Tools.
+- Erforderliche .NET SDKs (z. B. net8.0, net9.0).
+- Für Dev-Lösungen: Neben-Repo `..\Standard-Toolkit` auf passendem Branch.
+
+### Verwendung
+```
+build-all.cmd [Configuration] [Mode] [Rebuild]
+```
+- Configuration: `Debug` oder `Release` (Standard: `Release`)
+- Mode: `all` | `nuget` | `dev` (Standard: `all`)
+- Rebuild: `on` | `off` (Standard: `on`)
+
+### Beispiele
+- Alles in Release mit Rebuild (Standard):
+```
+build-all.cmd
+```
+- Nur NuGet, Debug, Rebuild aus (inkrementell):
+```
+build-all.cmd Debug nuget off
+```
+- Nur Dev, Release, Rebuild an:
+```
+build-all.cmd Release dev on
+```
+
+### Ausgaben & Logs
+- Binlogs: `Binaries\BuildLogs\<solution-name>.binlog`
+- Fehlerliste: `Binaries\BuildLogs\_failed.txt` (wird am Ende ausgegeben, falls vorhanden)
+- Konsole: ruhig, mit Zusammenfassung und Zeitstempeln
+
+### Binlog ansehen
+- Empfohlen: MSBuild Structured Log Viewer (`https://msbuildlog.com`).
+- Alternativ: `.binlog` direkt in Visual Studio öffnen (Datei → Öffnen → Datei).
+
+### Hinweise
+- Es wird ausschließlich VS 2022 verwendet; ältere MSBuild-Versionen werden ignoriert.
+- Dev-Builds warnen, falls `..\Standard-Toolkit` fehlt.
+
+---
+
+## Español
+
+### Descripción
+- Script: `build-all.cmd`
+- Objetivo: Compilar todas las soluciones (NuGet y Dev) con MSBuild, salida mínima en consola y generación de binlogs.
+
+### Requisitos
+- Visual Studio 2022 (cualquier edición) o VS 2022 Build Tools.
+- SDKs de .NET necesarios (p. ej., net8.0, net9.0).
+- Para soluciones Dev: repo hermano `..\Standard-Toolkit` en la rama correspondiente.
+
+### Uso
+```
+build-all.cmd [Configuration] [Mode] [Rebuild]
+```
+- Configuration: `Debug` o `Release` (por defecto: `Release`)
+- Mode: `all` | `nuget` | `dev` (por defecto: `all`)
+- Rebuild: `on` | `off` (por defecto: `on`)
+
+### Ejemplos
+- Todo en Release con Rebuild (por defecto):
+```
+build-all.cmd
+```
+- Solo NuGet, Debug, sin Rebuild (incremental):
+```
+build-all.cmd Debug nuget off
+```
+- Solo Dev, Release, con Rebuild:
+```
+build-all.cmd Release dev on
+```
+
+### Salida y logs
+- Binlogs: `Binaries\BuildLogs\<solution-name>.binlog`
+- Fallos: `Binaries\BuildLogs\_failed.txt` (se imprime al final si existe)
+- Consola: silenciosa con resumen y marcas de tiempo
+
+### Ver .binlog
+- Visor recomendado: MSBuild Structured Log Viewer (`https://msbuildlog.com`).
+- O abrir `.binlog` directamente en Visual Studio (Archivo → Abrir → Archivo).
+
+### Notas
+- Solo se usa VS 2022; se ignoran versiones anteriores de MSBuild.
+- Los builds Dev avisan si falta `..\Standard-Toolkit`.
+
+---
+
+## 中文（简体）
+
+### 概述
+- 脚本：`build-all.cmd`
+- 作用：使用 MSBuild 构建仓库内所有解决方案（NuGet 与 Dev），控制台输出精简，并生成 binlog。
+
+### 前置条件
+- 必须安装 Visual Studio 2022（任意版本）或 VS 2022 Build Tools。
+- 安装所需的 .NET SDK（如 net8.0、net9.0）。
+- 对于 Dev 解决方案：需要同级目录下的 `..\Standard-Toolkit` 仓库（分支需匹配）。
+
+### 用法
+```
+build-all.cmd [Configuration] [Mode] [Rebuild]
+```
+- Configuration：`Debug` 或 `Release`（默认：`Release`）
+- Mode：`all` | `nuget` | `dev`（默认：`all`）
+- Rebuild：`on` | `off`（默认：`on`）
+
+### 示例
+- 使用默认设置（Release + Rebuild）：
+```
+build-all.cmd
+```
+- 仅构建 NuGet，Debug，增量构建：
+```
+build-all.cmd Debug nuget off
+```
+- 仅构建 Dev，Release，强制重建：
+```
+build-all.cmd Release dev on
+```
+
+### 输出与日志
+- Binlog：`Binaries\BuildLogs\<solution-name>.binlog`
+- 失败清单：`Binaries\BuildLogs\_failed.txt`（若存在将于结束时打印）
+- 控制台输出：安静模式，带摘要与时间戳
+
+### 查看 .binlog
+- 推荐：MSBuild Structured Log Viewer（`https://msbuildlog.com`）。
+- 或在 Visual Studio 中直接打开 `.binlog`（文件 → 打开 → 文件）。
+
+### 说明
+- 仅使用 VS 2022；旧版 MSBuild 将被忽略。
+- Dev 构建会在缺少 `..\Standard-Toolkit` 时给出提示。


### PR DESCRIPTION
Implements #254 . Adds for #82 a build script (see below).

As title says. Fixed some compile error(s) and several warnings, too.

@PWagner1 - if this isn't the right time (or NuGet package version), let me know 😃 

---

### What changed
- BinaryFormatter warnings:
  - Added `<GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>` in several `.csproj` files, but then went for repo-wide solution (see below section)
  - This suppresses the BinaryFormatter ImageListStream warning for the existing WinForms designer resources.

- High DPI manifest warnings for .NET 8/9:
  - Created `app.core.manifest` without `<dpiAware>` and wired it conditionally for .NETCoreApp targets:
    - Added new files:
      - `Source/Krypton Docking Examples/Docking Persistence/app.core.manifest`
      - `Source/Krypton Docking Examples/Multi Control Docking/app.core.manifest`
      - `Source/Krypton Docking Examples/Navigator + FloatingWindows/app.core.manifest`
    - Updated `.csproj` to use manifests per framework:
      - In each of the three projects above, set:
        - `.NETFramework`: `<ApplicationManifest>app.manifest</ApplicationManifest>`
        - `.NETCoreApp`: `<ApplicationManifest>app.core.manifest</ApplicationManifest>`
  - This removes the “Remove high DPI settings from app.manifest and configure via Application.SetHighDpiMode API or 'ApplicationHighDpiMode' project property” warnings for net8/net9, while keeping net48 behavior unchanged.

### Additional changes and fixes

- **Repo-wide MSBuild config**
  - Added `Directory.Build.props` to set `GenerateResourceWarnOnBinaryFormatterUse=false` for all projects (suppresses ImageList BinaryFormatter warnings).
  - Added `Directory.Build.targets` to use `$(MSBuildThisFileDirectory)app.core.manifest` for `.NETCoreApp` targets only (keeps .NET Framework using per-project `app.manifest`).
  - Added root `app.core.manifest` (no `<dpiAware>`, includes `longPathAware`).

- **Project-level fixes (initial set)**
  - Updated five Docking example `.csproj` files to include `GenerateResourceWarnOnBinaryFormatterUse=false`.
  - For three Docking examples, added conditional `ApplicationManifest` per TFM and created local `app.core.manifest` files.

- **Build automation script**
  - Added `build-all.cmd` to build all solutions:
    - Supports args: `[Configuration] [Mode] [Rebuild]` with defaults `Release`, `all`, `on`.
    - Builds only `* - Nuget.sln` and `* - Dev.sln`.
    - Strictly uses VS 2022 MSBuild (explicit paths; `vswhere` constrained to `[17.0,18.0)`) and prints resolved path.
    - Quiet console output: `/v:quiet /clp:Summary;ShowTimestamp /nologo`.
    - Generates per-solution binlogs in `Binaries/BuildLogs`.
    - Tracks failures in `Binaries/BuildLogs/_failed.txt` and prints them; prints success message if none.

- **Documentation**
  - Added `build-all.md` with usage guide in English, German, Spanish, and Simplified Chinese.

### Results
- No more BinaryFormatter warnings on the listed Form1.resx files.
- No more High DPI manifest warnings for projects when building net8/net9.
- .NET Framework builds still use the original `app.manifest` with `<dpiAware>true</dpiAware>`.
- Usefull `build-all.cmd` script with final failed/success message for different build variations.
